### PR TITLE
Add Node Distance Multiplier to Obsidian Graph

### DIFF
--- a/frontend/src/components/visualization/ObsidianGraph.js
+++ b/frontend/src/components/visualization/ObsidianGraph.js
@@ -26,6 +26,7 @@ const ObsidianGraph = ({
   const [connectionMode, setConnectionMode] = useState(false);
   const [sourceNode, setSourceNode] = useState(null);
   const [stats, setStats] = useState({ nodes: 0, edges: 0, clusters: 0 });
+  const [nodeDistanceMultiplier, setNodeDistanceMultiplier] = useState(1); // Multiplier for node distance
 
   // Theme colors (Obsidian-inspired dark theme)
   const theme = {
@@ -193,7 +194,7 @@ const ObsidianGraph = ({
     const simulation = d3.forceSimulation(nodes)
       .force('link', d3.forceLink(links)
         .id(d => d.id)
-        .distance(d => 100 / d.strength)
+        .distance(d => (100 / d.strength) * nodeDistanceMultiplier) // Apply multiplier here
         .strength(d => d.strength * 0.3)
       )
       .force('charge', d3.forceManyBody()
@@ -630,6 +631,31 @@ const ObsidianGraph = ({
             </div>
           ))}
         </div>
+      </div>
+
+      {/* Node Distance Control */}
+      <div className="absolute bottom-20 right-4 bg-gray-800 bg-opacity-90 text-white rounded-lg shadow-lg p-3 z-10">
+        <label htmlFor="distance-slider" className="block text-sm font-medium mb-2">Node Distance Multiplier</label>
+        <input
+          id="distance-slider"
+          type="range"
+          min="1"
+          max="3"
+          step="0.1"
+          value={nodeDistanceMultiplier}
+          onChange={(e) => {
+            const newMultiplier = parseFloat(e.target.value);
+            setNodeDistanceMultiplier(newMultiplier);
+
+            // Restart simulation with updated multiplier
+            if (simulationRef.current) {
+              simulationRef.current.force('link').distance(d => (100 / d.strength) * newMultiplier);
+              simulationRef.current.alpha(1).restart();
+            }
+          }}
+          className="w-full"
+        />
+        <div className="text-xs mt-1">Multiplier: {nodeDistanceMultiplier.toFixed(1)}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request adds a user-adjustable control to the ObsidianGraph visualization, allowing users to dynamically change the distance between nodes in the graph. The main changes are the introduction of a "Node Distance Multiplier" slider in the UI and the corresponding update to the D3 force simulation logic to reflect the selected multiplier in real time.

**User Interface Enhancements:**

* Added a slider UI element labeled "Node Distance Multiplier" to the bottom-right of the graph, allowing users to adjust the spacing between nodes from 1.0 to 3.0 in increments of 0.1. When adjusted, the current value is displayed below the slider.

**Graph Layout Logic:**

* Introduced a new state variable `nodeDistanceMultiplier` (default 1) to control the node distance scaling.
* Modified the D3 force simulation so that the link distance is now calculated as `(100 / d.strength) * nodeDistanceMultiplier`, making the node spacing responsive to the slider.
* Updated the slider's change handler to restart the simulation with the new multiplier whenever the user interacts with the slider, ensuring immediate visual feedback.

<img width="978" height="471" alt="image" src="https://github.com/user-attachments/assets/e4b733fd-d411-47a3-9158-e2c4dda9dee3" />
