### PR TITLE
feat: Asset, Property & Transaction Tracking (issue #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to GHOST OSINT CRM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Added — Asset, Property & Transaction Tracking (issue #43)
+
+A unified system for recording persistent physical goods (assets), real estate
+(properties), and one-off transactions/benefits that flow between people,
+businesses, and places. Every change of hands or benefit is one row in a single
+`transactions` event log; assets get their chain of custody "for free" from the
+same log.
+
+- **New tables** (created in `backend/server.js` `initializeDatabase()`):
+  `properties`, `assets`, `transactions` — with indexes, `updated_at` triggers,
+  and `ON CONFLICT DO NOTHING` seeds.
+- **New `model_options` taxonomies**, editable in Settings → Data Model:
+  `transaction_type`, `transaction_item_category`, `asset_category`,
+  `asset_status`, `property_type`.
+- **Backend routes** (`requireAuth` + `validateIdParam`, list shape
+  `{ data, meta }`): `routes/properties.js`, `routes/assets.js`,
+  `routes/transactions.js`, `routes/ledger.js`. Convenience sub-routes:
+  `GET /api/people/:id/transactions`, `GET /api/people/:id/assets`,
+  `GET /api/businesses/:id/transactions`, `GET /api/businesses/:id/venue-stats`,
+  `GET /api/properties/:id/transactions`, and the unified entity ledger
+  `GET /api/:entityType/:id/ledger`.
+- **Polymorphic** giver/receiver (person | business | external), subject
+  (free-text item + category | asset | business | property), and event location
+  (business venue | property | free-text + geocode).
+- **Derived (never stored)** current holder / chain of custody for assets, and
+  current owner for businesses & properties (from `sale|purchase|transfer|acquisition`).
+- **Asset location model**: `with_holder` (rides the holder's latest known
+  position), `fixed_known` (live-linked to a person's `people.locations` entry with
+  coordinate snapshot fallback), `fixed_custom` (own geocoded address), `unknown`.
+- **Geocoding** of asset/property/transaction free-text addresses via
+  `improvedGeocodingService`; failures are non-fatal and surface a reason.
+- **Frontend**: new sections (Properties, Assets, Transactions) with list /
+  add-edit / detail components, `DataContext` slices, `assetsAPI`/`propertiesAPI`/
+  `transactionsAPI`/`ledgerAPI`. Detail panels on Person (Gifts & Transactions,
+  Assets Held, Ledger), Business (Venue Activity, Transactions, Ledger), Asset and
+  Property (chain-of-custody timelines).
+- **Entity Ledger** view (`EntityLedger.js`) + exportable "Entity Ledger" report
+  type (markdown / .docx via the existing Report Generator).
+- **Global Map**: property / asset / transaction layers with toggles and
+  type/category filters.
+- **Entity-network graph**: toggleable venue/transaction layer rendering businesses
+  and properties as hubs with edge thickness reflecting event count.
+- **Tests**: `backend/utils/transactionHelpers.test.js` covering party/subject/
+  location resolution, derived custody, geocoding, venue-stats aggregation, ledger
+  role/value-direction derivation, and transaction validation rules.
+
+#### Deferred (Phase 2)
+- Cross-venue ranked "influence" leaderboard and trend analytics.
+- Per-transaction historical coordinates of a moving asset (reconstructable from
+  the holder's `travel_history`).
+- Auto-mutating `owner_person_id` from the custody chain (current owner stays
+  derived for display; the quick field is left untouched).
+- Bulk import.
+
 ## [2.6.0] - 2026-06-14
 
 ### 🧹 Cleanup

--- a/backend/routes/assets.js
+++ b/backend/routes/assets.js
@@ -1,0 +1,287 @@
+// File: backend/routes/assets.js
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+const { validateIdParam } = require('../middleware/validation');
+const { TX_SELECT, decorateTransaction, geocodeFields, deriveCustody, fullName } = require('../utils/transactionHelpers');
+
+const LOCATION_MODES = ['with_holder', 'fixed_known', 'fixed_custom', 'unknown'];
+const num = (v) => (v == null ? null : parseFloat(v));
+
+// Build a holder object from the latest-transaction join columns (alias prefix lt_).
+function holderFromRow(row) {
+  if (row.lt_to_person_id) return { type: 'person', id: row.lt_to_person_id, label: fullName(row.lt_to_person_first, row.lt_to_person_last) || `Person #${row.lt_to_person_id}`, since: row.lt_occurred_on };
+  if (row.lt_to_business_id) return { type: 'business', id: row.lt_to_business_id, label: row.lt_to_business_name || `Business #${row.lt_to_business_id}`, since: row.lt_occurred_on };
+  if (row.lt_to_external) return { type: 'external', id: null, label: row.lt_to_external, since: row.lt_occurred_on };
+  return null;
+}
+
+const HOLDER_JOIN = `
+  LEFT JOIN LATERAL (
+    SELECT tx.to_person_id AS lt_to_person_id, tx.to_business_id AS lt_to_business_id,
+           tx.to_external AS lt_to_external, tx.occurred_on AS lt_occurred_on
+    FROM transactions tx
+    WHERE tx.subject_asset_id = a.id
+    ORDER BY tx.occurred_on DESC NULLS LAST, tx.id DESC LIMIT 1
+  ) lt ON true
+  LEFT JOIN people     ltp ON lt.lt_to_person_id   = ltp.id
+  LEFT JOIN businesses ltb ON lt.lt_to_business_id = ltb.id
+`;
+const HOLDER_COLS = `
+  lt.lt_to_person_id, lt.lt_to_business_id, lt.lt_to_external, lt.lt_occurred_on,
+  ltp.first_name AS lt_to_person_first, ltp.last_name AS lt_to_person_last,
+  ltb.name AS lt_to_business_name
+`;
+
+// Resolve the live position of an asset based on its location_mode.
+async function resolveAssetLocation(asset, holder) {
+  const mode = asset.location_mode || 'with_holder';
+  if (mode === 'fixed_custom') {
+    return { mode, latitude: num(asset.latitude), longitude: num(asset.longitude), label: asset.location_name || [asset.city, asset.country].filter(Boolean).join(', ') || null, source: 'asset' };
+  }
+  if (mode === 'fixed_known') {
+    if (asset.location_person_id) {
+      const pr = await pool.query('SELECT locations FROM people WHERE id = $1', [asset.location_person_id]);
+      const locs = (pr.rows[0] && pr.rows[0].locations) || [];
+      let entry = null;
+      if (asset.location_ref != null) {
+        const idx = parseInt(asset.location_ref, 10);
+        if (!isNaN(idx) && locs[idx]) entry = locs[idx];
+        if (!entry) entry = locs.find(l => String(l.id) === String(asset.location_ref));
+      }
+      if (entry && entry.latitude && entry.longitude) {
+        return { mode, latitude: num(entry.latitude), longitude: num(entry.longitude), label: entry.location_name || entry.address || 'Linked location', source: 'people.locations' };
+      }
+    }
+    return { mode, latitude: num(asset.latitude), longitude: num(asset.longitude), label: asset.location_name || 'Snapshot location', source: 'snapshot' };
+  }
+  if (mode === 'with_holder') {
+    if (!holder) return { mode, latitude: null, longitude: null, label: null, source: 'unknown' };
+    if (holder.type === 'person') {
+      const th = await pool.query(
+        `SELECT latitude, longitude, location_name, city, country FROM travel_history
+         WHERE person_id = $1 AND latitude IS NOT NULL
+         ORDER BY COALESCE(departure_date, arrival_date) DESC NULLS LAST, id DESC LIMIT 1`, [holder.id]);
+      if (th.rows[0]) {
+        const r = th.rows[0];
+        return { mode, latitude: num(r.latitude), longitude: num(r.longitude), label: r.location_name || [r.city, r.country].filter(Boolean).join(', ') || holder.label, source: 'travel_history', holder };
+      }
+      const pr = await pool.query('SELECT locations FROM people WHERE id = $1', [holder.id]);
+      const locs = (pr.rows[0] && pr.rows[0].locations) || [];
+      const entry = locs.find(l => l.location_type === 'primary_residence' && l.latitude && l.longitude) || locs.find(l => l.latitude && l.longitude);
+      if (entry) return { mode, latitude: num(entry.latitude), longitude: num(entry.longitude), label: entry.location_name || entry.address || holder.label, source: 'people.locations', holder };
+      return { mode, latitude: null, longitude: null, label: holder.label, source: 'holder_unknown', holder };
+    }
+    if (holder.type === 'business') {
+      const b = await pool.query('SELECT latitude, longitude, name FROM businesses WHERE id = $1', [holder.id]);
+      if (b.rows[0] && b.rows[0].latitude) return { mode, latitude: num(b.rows[0].latitude), longitude: num(b.rows[0].longitude), label: b.rows[0].name, source: 'business', holder };
+      return { mode, latitude: null, longitude: null, label: holder.label, source: 'holder_unknown', holder };
+    }
+    return { mode, latitude: null, longitude: null, label: holder.label, source: 'external', holder };
+  }
+  return { mode: 'unknown', latitude: null, longitude: null, label: null, source: 'unknown' };
+}
+
+// GET / — list assets
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 1000);
+    const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+
+    const where = [];
+    const params = [];
+    if (req.query.category) { params.push(req.query.category); where.push(`a.category = $${params.length}`); }
+    if (req.query.status) { params.push(req.query.status); where.push(`a.status = $${params.length}`); }
+    if (req.query.case_id) { params.push(parseInt(req.query.case_id, 10)); where.push(`a.case_id = $${params.length}`); }
+    if (req.query.q) { params.push(`%${req.query.q}%`); where.push(`(a.name ILIKE $${params.length} OR a.identifier ILIKE $${params.length})`); }
+    if (req.query.holder_person_id) {
+      params.push(parseInt(req.query.holder_person_id, 10));
+      where.push(`lt.lt_to_person_id = $${params.length}`);
+    }
+    if (req.query.bbox) {
+      const [w, s, e, n] = String(req.query.bbox).split(',').map(Number);
+      if ([w, s, e, n].every(v => !isNaN(v))) {
+        params.push(w, s, e, n);
+        where.push(`a.longitude BETWEEN $${params.length - 3} AND $${params.length - 1} AND a.latitude BETWEEN $${params.length - 2} AND $${params.length}`);
+      }
+    }
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const dataResult = await pool.query(
+      `SELECT a.*, ${HOLDER_COLS} FROM assets a ${HOLDER_JOIN} ${whereSql}
+       ORDER BY a.created_at DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
+    );
+    const countResult = await pool.query(
+      `SELECT COUNT(*)::int AS count FROM assets a ${HOLDER_JOIN} ${whereSql}`, params);
+    const total = countResult.rows[0].count;
+
+    const data = [];
+    for (const row of dataResult.rows) {
+      const holder = holderFromRow(row);
+      const location = await resolveAssetLocation(row, holder);
+      const clean = { ...row };
+      ['lt_to_person_id', 'lt_to_business_id', 'lt_to_external', 'lt_occurred_on', 'lt_to_person_first', 'lt_to_person_last', 'lt_to_business_name'].forEach(k => delete clean[k]);
+      data.push({ ...clean, current_holder: holder, resolved_location: location });
+    }
+
+    res.set('X-Total-Count', String(total));
+    res.set('X-Has-More', String(offset + data.length < total));
+    res.json({ data, meta: { total, limit, offset, hasMore: offset + data.length < total } });
+  } catch (err) {
+    console.error('Error fetching assets:', err);
+    res.status(500).json({ error: 'Failed to fetch assets' });
+  }
+});
+
+function validateAssetBody(body) {
+  if (!body.name || typeof body.name !== 'string' || !body.name.trim()) return 'Asset name is required';
+  const mode = body.location_mode || 'with_holder';
+  if (!LOCATION_MODES.includes(mode)) return `location_mode must be one of: ${LOCATION_MODES.join(', ')}`;
+  if (mode === 'fixed_known' && !body.location_person_id) return 'location_person_id is required when location_mode is fixed_known';
+  if (mode === 'fixed_custom' && body.latitude == null && body.longitude == null && !body.address && !body.city && !body.country) {
+    return 'fixed_custom location requires an address or coordinates';
+  }
+  if (body.estimated_value != null && (isNaN(Number(body.estimated_value)) || Number(body.estimated_value) < 0)) return 'estimated_value must be a non-negative number';
+  return null;
+}
+
+// POST / — create asset (optional initial_holder seeds an acquisition transaction)
+router.post('/', requireAuth, async (req, res) => {
+  const clientErr = validateAssetBody(req.body);
+  if (clientErr) return res.status(400).json({ error: clientErr });
+
+  const b = req.body;
+  const mode = b.location_mode || 'with_holder';
+  try {
+    let geo = { latitude: b.latitude, longitude: b.longitude, geocode_confidence: null, geocode_provider: null, geocoded_at: null, geocode_failure: null };
+
+    if (mode === 'fixed_custom' && (b.latitude == null || b.longitude == null) && (b.address || b.city || b.country)) {
+      geo = await geocodeFields(req.app.locals.improvedGeocodingService, { address: b.address, city: b.city, state: b.state, country: b.country });
+    } else if (mode === 'fixed_known' && b.location_person_id && b.location_ref != null) {
+      // snapshot the chosen people.locations entry coords
+      const pr = await pool.query('SELECT locations FROM people WHERE id = $1', [b.location_person_id]);
+      const locs = (pr.rows[0] && pr.rows[0].locations) || [];
+      const idx = parseInt(b.location_ref, 10);
+      const entry = (!isNaN(idx) && locs[idx]) || locs.find(l => String(l.id) === String(b.location_ref));
+      if (entry) { geo.latitude = entry.latitude || null; geo.longitude = entry.longitude || null; b.location_name = b.location_name || entry.location_name || entry.address; }
+    }
+
+    const result = await pool.query(
+      `INSERT INTO assets
+        (name, category, identifier, description, notes, estimated_value, currency, status,
+         location_mode, location_person_id, location_ref, location_name, address, city, state, country, postal_code,
+         latitude, longitude, geocode_confidence, geocode_provider, geocoded_at, case_id)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23) RETURNING *`,
+      [b.name.trim(), b.category || null, b.identifier || null, b.description || null, b.notes || null,
+       b.estimated_value != null ? b.estimated_value : null, b.currency || null, b.status || 'active',
+       mode, b.location_person_id || null, b.location_ref != null ? String(b.location_ref) : null, b.location_name || null,
+       b.address || null, b.city || null, b.state || null, b.country || null, b.postal_code || null,
+       geo.latitude, geo.longitude, geo.geocode_confidence, geo.geocode_provider, geo.geocoded_at, b.case_id || null]
+    );
+    const asset = result.rows[0];
+
+    // optional initial holder → acquisition transaction
+    const ih = b.initial_holder;
+    if (ih && (ih.person_id || ih.business_id || ih.external)) {
+      const occurred = ih.occurred_on || new Date().toISOString().slice(0, 10);
+      await pool.query(
+        `INSERT INTO transactions (transaction_type, subject_asset_id, to_person_id, to_business_id, to_external, occurred_on, case_id)
+         VALUES ('acquisition', $1, $2, $3, $4, $5, $6)`,
+        [asset.id, ih.person_id || null, ih.business_id || null, ih.external || null, occurred, b.case_id || null]);
+    }
+
+    res.status(201).json({ ...asset, geocode_failure: geo.geocode_failure });
+  } catch (err) {
+    console.error('Error creating asset:', err);
+    res.status(500).json({ error: 'Failed to create asset' });
+  }
+});
+
+// GET /:id — detail + chain of custody + resolved location
+router.get('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const assetResult = await pool.query('SELECT * FROM assets WHERE id = $1', [id]);
+    if (assetResult.rows.length === 0) return res.status(404).json({ error: 'Asset not found' });
+    const asset = assetResult.rows[0];
+
+    const txResult = await pool.query(
+      `${TX_SELECT} WHERE t.subject_asset_id = $1 ORDER BY t.occurred_on ASC NULLS FIRST, t.id ASC`, [id]);
+    const decorated = txResult.rows.map(decorateTransaction);
+    const { currentHolder, since, chain } = deriveCustody(decorated);
+    const location = await resolveAssetLocation(asset, currentHolder);
+
+    res.json({
+      ...asset,
+      current_holder: currentHolder,
+      holder_since: since,
+      chain_of_custody: chain,
+      transactions: decorated,
+      resolved_location: location,
+    });
+  } catch (err) {
+    console.error('Error fetching asset:', err);
+    res.status(500).json({ error: 'Failed to fetch asset' });
+  }
+});
+
+// PUT /:id — update (incl. location_mode changes)
+router.put('/:id', requireAuth, validateIdParam, async (req, res) => {
+  const clientErr = validateAssetBody(req.body);
+  if (clientErr) return res.status(400).json({ error: clientErr });
+  const b = req.body;
+  const mode = b.location_mode || 'with_holder';
+  try {
+    const existing = await pool.query('SELECT * FROM assets WHERE id = $1', [req.params.id]);
+    if (existing.rows.length === 0) return res.status(404).json({ error: 'Asset not found' });
+
+    let geo = { latitude: b.latitude, longitude: b.longitude, geocode_confidence: existing.rows[0].geocode_confidence, geocode_provider: existing.rows[0].geocode_provider, geocoded_at: existing.rows[0].geocoded_at, geocode_failure: null };
+    if (mode === 'fixed_custom' && (b.latitude == null || b.longitude == null) && (b.address || b.city || b.country)) {
+      geo = await geocodeFields(req.app.locals.improvedGeocodingService, { address: b.address, city: b.city, state: b.state, country: b.country });
+    } else if (mode === 'fixed_known' && b.location_person_id && b.location_ref != null) {
+      const pr = await pool.query('SELECT locations FROM people WHERE id = $1', [b.location_person_id]);
+      const locs = (pr.rows[0] && pr.rows[0].locations) || [];
+      const idx = parseInt(b.location_ref, 10);
+      const entry = (!isNaN(idx) && locs[idx]) || locs.find(l => String(l.id) === String(b.location_ref));
+      if (entry) { geo.latitude = entry.latitude || null; geo.longitude = entry.longitude || null; b.location_name = b.location_name || entry.location_name || entry.address; }
+    }
+
+    const result = await pool.query(
+      `UPDATE assets SET
+         name=$1, category=$2, identifier=$3, description=$4, notes=$5, estimated_value=$6, currency=$7, status=$8,
+         location_mode=$9, location_person_id=$10, location_ref=$11, location_name=$12, address=$13, city=$14, state=$15,
+         country=$16, postal_code=$17, latitude=$18, longitude=$19, geocode_confidence=$20, geocode_provider=$21,
+         geocoded_at=$22, case_id=$23, updated_at=CURRENT_TIMESTAMP
+       WHERE id=$24 RETURNING *`,
+      [b.name.trim(), b.category || null, b.identifier || null, b.description || null, b.notes || null,
+       b.estimated_value != null ? b.estimated_value : null, b.currency || null, b.status || 'active',
+       mode, b.location_person_id || null, b.location_ref != null ? String(b.location_ref) : null, b.location_name || null,
+       b.address || null, b.city || null, b.state || null, b.country || null, b.postal_code || null,
+       geo.latitude, geo.longitude, geo.geocode_confidence, geo.geocode_provider, geo.geocoded_at, b.case_id || null, req.params.id]
+    );
+    res.json({ ...result.rows[0], geocode_failure: geo.geocode_failure });
+  } catch (err) {
+    console.error('Error updating asset:', err);
+    res.status(500).json({ error: 'Failed to update asset' });
+  }
+});
+
+// DELETE /:id
+router.delete('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const result = await pool.query('DELETE FROM assets WHERE id = $1 RETURNING *', [req.params.id]);
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Asset not found' });
+    res.json({ message: 'Asset deleted successfully' });
+  } catch (err) {
+    console.error('Error deleting asset:', err);
+    res.status(500).json({ error: 'Failed to delete asset' });
+  }
+});
+
+module.exports = router;
+module.exports.resolveAssetLocation = resolveAssetLocation;
+module.exports.holderFromRow = holderFromRow;
+module.exports.HOLDER_JOIN = HOLDER_JOIN;
+module.exports.HOLDER_COLS = HOLDER_COLS;

--- a/backend/routes/assets.js
+++ b/backend/routes/assets.js
@@ -5,10 +5,13 @@ const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
 const { TX_SELECT, decorateTransaction, geocodeFields, deriveCustody, fullName } = require('../utils/transactionHelpers');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
 const LOCATION_MODES = ['with_holder', 'fixed_known', 'fixed_custom', 'unknown'];
 const num = (v) => (v == null ? null : parseFloat(v));
 
+
+router.use(apiLimiter);
 // Build a holder object from the latest-transaction join columns (alias prefix lt_).
 function holderFromRow(row) {
   if (row.lt_to_person_id) return { type: 'person', id: row.lt_to_person_id, label: fullName(row.lt_to_person_first, row.lt_to_person_last) || `Person #${row.lt_to_person_id}`, since: row.lt_occurred_on };

--- a/backend/routes/auditLogs.js
+++ b/backend/routes/auditLogs.js
@@ -3,7 +3,10 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAdmin } = require('../middleware/auth');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Get audit logs with filtering and pagination
 router.get('/', requireAdmin, async (req, res) => {
   try {

--- a/backend/routes/businesses.js
+++ b/backend/routes/businesses.js
@@ -7,7 +7,6 @@ const logAudit = require('../utils/logAudit');
 const { apiLimiter } = require('../middleware/rateLimiters');
 
 router.use(apiLimiter);
-
 // GET / — list all businesses
 router.get('/', requireAuth, async (req, res) => {
   try {

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 router.get('/', requireAuth, async (req, res) => {
   try {
     const result = await pool.query('SELECT * FROM cases ORDER BY case_name ASC');

--- a/backend/routes/entityNetwork.js
+++ b/backend/routes/entityNetwork.js
@@ -2,7 +2,10 @@
 const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/database');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Entity relationships endpoints
 router.get('/entity-relationships', async (req, res) => {
   try {

--- a/backend/routes/ledger.js
+++ b/backend/routes/ledger.js
@@ -6,9 +6,12 @@ const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
 const { TX_SELECT, decorateTransaction, fullName, aggregateVenueStats, deriveLedger } = require('../utils/transactionHelpers');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
 const ENTITY_TYPES = { people: 'person', businesses: 'business', properties: 'property' };
 
+
+router.use(apiLimiter);
 // ── Convenience sub-routes ────────────────────────────────────────────────
 
 // GET /people/:id/transactions — given + received (direction per row)

--- a/backend/routes/ledger.js
+++ b/backend/routes/ledger.js
@@ -1,0 +1,255 @@
+// File: backend/routes/ledger.js
+// Convenience sub-routes + entity ledger + venue analytics for the transaction feature.
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+const { validateIdParam } = require('../middleware/validation');
+const { TX_SELECT, decorateTransaction, fullName } = require('../utils/transactionHelpers');
+
+const ENTITY_TYPES = { people: 'person', businesses: 'business', properties: 'property' };
+
+// ── Convenience sub-routes ────────────────────────────────────────────────
+
+// GET /people/:id/transactions — given + received (direction per row)
+router.get('/people/:id/transactions', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const result = await pool.query(
+      `${TX_SELECT} WHERE t.from_person_id = $1 OR t.to_person_id = $1
+       ORDER BY t.occurred_on DESC NULLS LAST, t.id DESC`, [id]);
+    const rows = result.rows.map(r => {
+      const d = decorateTransaction(r);
+      d.direction = r.to_person_id === id ? 'received' : 'given';
+      return d;
+    });
+    res.json({ data: rows, meta: { total: rows.length } });
+  } catch (err) {
+    console.error('Error fetching person transactions:', err);
+    res.status(500).json({ error: 'Failed to fetch person transactions' });
+  }
+});
+
+// GET /people/:id/assets — assets currently held by this person (derived)
+router.get('/people/:id/assets', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const rows = await currentHoldings('person', req.params.id);
+    res.json({ data: rows, meta: { total: rows.length } });
+  } catch (err) {
+    console.error('Error fetching person assets:', err);
+    res.status(500).json({ error: 'Failed to fetch person assets' });
+  }
+});
+
+// GET /businesses/:id/transactions — party | subject | venue (role per row)
+router.get('/businesses/:id/transactions', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const result = await pool.query(
+      `${TX_SELECT} WHERE t.from_business_id = $1 OR t.to_business_id = $1
+        OR t.subject_business_id = $1 OR t.location_business_id = $1
+       ORDER BY t.occurred_on DESC NULLS LAST, t.id DESC`, [id]);
+    const rows = result.rows.map(r => {
+      const d = decorateTransaction(r);
+      if (r.location_business_id === id) d.role = 'venue';
+      else if (r.subject_business_id === id) d.role = 'subject';
+      else if (r.to_business_id === id) d.role = 'received';
+      else d.role = 'gave';
+      return d;
+    });
+    res.json({ data: rows, meta: { total: rows.length } });
+  } catch (err) {
+    console.error('Error fetching business transactions:', err);
+    res.status(500).json({ error: 'Failed to fetch business transactions' });
+  }
+});
+
+// GET /businesses/:id/venue-stats — venue analytics
+router.get('/businesses/:id/venue-stats', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const bizResult = await pool.query('SELECT id, name FROM businesses WHERE id = $1', [id]);
+    if (bizResult.rows.length === 0) return res.status(404).json({ error: 'Business not found' });
+
+    const txResult = await pool.query(
+      `${TX_SELECT} WHERE t.location_business_id = $1 ORDER BY t.occurred_on ASC NULLS FIRST, t.id ASC`, [id]);
+    const txns = txResult.rows.map(decorateTransaction);
+
+    const peopleMap = new Map();
+    const byType = {};
+    let firstEvent = null, lastEvent = null;
+    for (const t of txns) {
+      byType[t.transaction_type] = (byType[t.transaction_type] || 0) + 1;
+      if (t.occurred_on) {
+        if (!firstEvent || t.occurred_on < firstEvent) firstEvent = t.occurred_on;
+        if (!lastEvent || t.occurred_on > lastEvent) lastEvent = t.occurred_on;
+      }
+      for (const party of [t.resolved_from, t.resolved_to]) {
+        if (party && party.type === 'person' && party.id) {
+          const cur = peopleMap.get(party.id) || { id: party.id, label: party.label, event_count: 0 };
+          cur.event_count += 1;
+          peopleMap.set(party.id, cur);
+        }
+      }
+    }
+    const people = Array.from(peopleMap.values()).sort((a, b) => b.event_count - a.event_count);
+
+    res.json({
+      business: { id: bizResult.rows[0].id, label: bizResult.rows[0].name },
+      event_count: txns.length,
+      distinct_people: people.length,
+      people,
+      first_event: firstEvent,
+      last_event: lastEvent,
+      by_type: byType,
+    });
+  } catch (err) {
+    console.error('Error fetching venue stats:', err);
+    res.status(500).json({ error: 'Failed to fetch venue stats' });
+  }
+});
+
+// ── Entity ledger ─────────────────────────────────────────────────────────
+
+async function currentHoldings(entityKind, id) {
+  const col = entityKind === 'person' ? 'to_person_id' : 'to_business_id';
+  const result = await pool.query(
+    `SELECT a.id, a.name, lt.since FROM assets a
+     JOIN LATERAL (
+       SELECT tx.${col} AS holder_id, tx.occurred_on AS since
+       FROM transactions tx WHERE tx.subject_asset_id = a.id
+       ORDER BY tx.occurred_on DESC NULLS LAST, tx.id DESC LIMIT 1
+     ) lt ON true
+     WHERE lt.holder_id = $1
+     ORDER BY a.name ASC`, [id]);
+  return result.rows.map(r => ({ id: r.id, name: r.name, since: r.since }));
+}
+
+// GET /:entityType/:id/ledger
+router.get('/:entityType/:id/ledger', requireAuth, validateIdParam, async (req, res) => {
+  const { entityType } = req.params;
+  const id = req.params.id;
+  const kind = ENTITY_TYPES[entityType];
+  if (!kind) return res.status(400).json({ error: 'Invalid entity type for ledger' });
+
+  try {
+    // entity label
+    let label = null;
+    if (kind === 'person') {
+      const r = await pool.query('SELECT first_name, last_name FROM people WHERE id = $1', [id]);
+      if (r.rows.length === 0) return res.status(404).json({ error: 'Entity not found' });
+      label = fullName(r.rows[0].first_name, r.rows[0].last_name);
+    } else if (kind === 'business') {
+      const r = await pool.query('SELECT name FROM businesses WHERE id = $1', [id]);
+      if (r.rows.length === 0) return res.status(404).json({ error: 'Entity not found' });
+      label = r.rows[0].name;
+    } else {
+      const r = await pool.query('SELECT name FROM properties WHERE id = $1', [id]);
+      if (r.rows.length === 0) return res.status(404).json({ error: 'Entity not found' });
+      label = r.rows[0].name;
+    }
+
+    // role-match clause
+    const filters = [];
+    const params = [id];
+    if (kind === 'person') filters.push(`(t.from_person_id = $1 OR t.to_person_id = $1)`);
+    if (kind === 'business') filters.push(`(t.from_business_id = $1 OR t.to_business_id = $1 OR t.subject_business_id = $1 OR t.location_business_id = $1)`);
+    if (kind === 'property') filters.push(`(t.subject_property_id = $1 OR t.location_property_id = $1)`);
+    if (req.query.case_id) { params.push(parseInt(req.query.case_id, 10)); filters.push(`t.case_id = $${params.length}`); }
+    if (req.query.date_from) { params.push(req.query.date_from); filters.push(`t.occurred_on >= $${params.length}`); }
+    if (req.query.date_to) { params.push(req.query.date_to); filters.push(`t.occurred_on <= $${params.length}`); }
+
+    const txResult = await pool.query(
+      `${TX_SELECT} WHERE ${filters.join(' AND ')} ORDER BY t.occurred_on ASC NULLS FIRST, t.id ASC`, params);
+    const txns = txResult.rows.map(decorateTransaction);
+
+    const entries = [];
+    const seen = new Set();
+    const counterpartyKeys = new Set();
+    const countByType = {};
+    const byCurrencyMap = new Map();
+
+    const ensureCurrency = (cur) => {
+      const c = cur || 'UNSPEC';
+      if (!byCurrencyMap.has(c)) byCurrencyMap.set(c, { currency: cur || null, value_in: 0, value_out: 0, net: 0 });
+      return byCurrencyMap.get(c);
+    };
+
+    for (const t of txns) {
+      countByType[t.transaction_type] = (countByType[t.transaction_type] || 0) + 1;
+      const raw = txResult.rows.find(r => r.id === t.id);
+      const isTo = kind === 'person' ? raw.to_person_id === id : kind === 'business' ? raw.to_business_id === id : false;
+      const isFrom = kind === 'person' ? raw.from_person_id === id : kind === 'business' ? raw.from_business_id === id : false;
+      const isSubject = kind === 'business' ? raw.subject_business_id === id : kind === 'property' ? raw.subject_property_id === id : false;
+      const isVenue = kind === 'business' ? raw.location_business_id === id : kind === 'property' ? raw.location_property_id === id : false;
+      const value = t.value != null ? parseFloat(t.value) : null;
+
+      const pushEntry = (role, value_direction, counterparty, entryValue) => {
+        const key = `${t.id}:${role}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        if (counterparty && counterparty.label) counterpartyKeys.add(`${counterparty.type}:${counterparty.id}:${counterparty.label}`);
+        entries.push({
+          transaction_id: t.id,
+          occurred_on: t.occurred_on,
+          transaction_type: t.transaction_type,
+          role,
+          counterparty: counterparty || null,
+          subject: t.resolved_subject,
+          location: t.resolved_location,
+          value: entryValue,
+          currency: t.currency,
+          value_direction,
+          notes: t.notes,
+        });
+      };
+
+      if (isTo) {
+        pushEntry('received', 'in', t.resolved_from, value);
+        if (value != null) { const c = ensureCurrency(t.currency); c.value_in += value; }
+        if (raw.subject_asset_id) pushEntry('acquired_custody', 'in', t.resolved_from, null);
+      }
+      if (isFrom) {
+        pushEntry('gave', 'out', t.resolved_to, value);
+        if (value != null) { const c = ensureCurrency(t.currency); c.value_out += value; }
+        if (raw.subject_asset_id) pushEntry('released_custody', 'out', t.resolved_to, null);
+      }
+      if (isSubject) pushEntry('subject', 'neutral', t.resolved_from || t.resolved_to, value);
+      if (isVenue) pushEntry('venue', 'neutral', t.resolved_from || t.resolved_to, value);
+    }
+
+    entries.sort((a, b) => {
+      const da = a.occurred_on || ''; const db = b.occurred_on || '';
+      if (da === db) return a.transaction_id - b.transaction_id;
+      return da < db ? -1 : 1;
+    });
+
+    const byCurrency = Array.from(byCurrencyMap.values()).map(c => ({ ...c, net: c.value_in - c.value_out }));
+    const totalIn = byCurrency.reduce((s, c) => s + c.value_in, 0);
+    const totalOut = byCurrency.reduce((s, c) => s + c.value_out, 0);
+    const singleCurrency = byCurrency.length <= 1;
+
+    let assetsHeld = [];
+    if (kind === 'person') assetsHeld = await currentHoldings('person', id);
+    else if (kind === 'business') assetsHeld = await currentHoldings('business', id);
+
+    res.json({
+      entity: { type: kind, id, label },
+      entries,
+      summary: {
+        value_in: singleCurrency ? totalIn : null,
+        value_out: singleCurrency ? totalOut : null,
+        net: singleCurrency ? totalIn - totalOut : null,
+        by_currency: byCurrency,
+        count_by_type: countByType,
+        distinct_counterparties: counterpartyKeys.size,
+        assets_currently_held: assetsHeld,
+      },
+    });
+  } catch (err) {
+    console.error('Error building ledger:', err);
+    res.status(500).json({ error: 'Failed to build ledger' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/ledger.js
+++ b/backend/routes/ledger.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
-const { TX_SELECT, decorateTransaction, fullName } = require('../utils/transactionHelpers');
+const { TX_SELECT, decorateTransaction, fullName, aggregateVenueStats, deriveLedger } = require('../utils/transactionHelpers');
 
 const ENTITY_TYPES = { people: 'person', businesses: 'business', properties: 'property' };
 
@@ -73,36 +73,9 @@ router.get('/businesses/:id/venue-stats', requireAuth, validateIdParam, async (r
 
     const txResult = await pool.query(
       `${TX_SELECT} WHERE t.location_business_id = $1 ORDER BY t.occurred_on ASC NULLS FIRST, t.id ASC`, [id]);
-    const txns = txResult.rows.map(decorateTransaction);
+    const stats = aggregateVenueStats(txResult.rows);
 
-    const peopleMap = new Map();
-    const byType = {};
-    let firstEvent = null, lastEvent = null;
-    for (const t of txns) {
-      byType[t.transaction_type] = (byType[t.transaction_type] || 0) + 1;
-      if (t.occurred_on) {
-        if (!firstEvent || t.occurred_on < firstEvent) firstEvent = t.occurred_on;
-        if (!lastEvent || t.occurred_on > lastEvent) lastEvent = t.occurred_on;
-      }
-      for (const party of [t.resolved_from, t.resolved_to]) {
-        if (party && party.type === 'person' && party.id) {
-          const cur = peopleMap.get(party.id) || { id: party.id, label: party.label, event_count: 0 };
-          cur.event_count += 1;
-          peopleMap.set(party.id, cur);
-        }
-      }
-    }
-    const people = Array.from(peopleMap.values()).sort((a, b) => b.event_count - a.event_count);
-
-    res.json({
-      business: { id: bizResult.rows[0].id, label: bizResult.rows[0].name },
-      event_count: txns.length,
-      distinct_people: people.length,
-      people,
-      first_event: firstEvent,
-      last_event: lastEvent,
-      by_type: byType,
-    });
+    res.json({ business: { id: bizResult.rows[0].id, label: bizResult.rows[0].name }, ...stats });
   } catch (err) {
     console.error('Error fetching venue stats:', err);
     res.status(500).json({ error: 'Failed to fetch venue stats' });
@@ -161,73 +134,8 @@ router.get('/:entityType/:id/ledger', requireAuth, validateIdParam, async (req, 
 
     const txResult = await pool.query(
       `${TX_SELECT} WHERE ${filters.join(' AND ')} ORDER BY t.occurred_on ASC NULLS FIRST, t.id ASC`, params);
-    const txns = txResult.rows.map(decorateTransaction);
 
-    const entries = [];
-    const seen = new Set();
-    const counterpartyKeys = new Set();
-    const countByType = {};
-    const byCurrencyMap = new Map();
-
-    const ensureCurrency = (cur) => {
-      const c = cur || 'UNSPEC';
-      if (!byCurrencyMap.has(c)) byCurrencyMap.set(c, { currency: cur || null, value_in: 0, value_out: 0, net: 0 });
-      return byCurrencyMap.get(c);
-    };
-
-    for (const t of txns) {
-      countByType[t.transaction_type] = (countByType[t.transaction_type] || 0) + 1;
-      const raw = txResult.rows.find(r => r.id === t.id);
-      const isTo = kind === 'person' ? raw.to_person_id === id : kind === 'business' ? raw.to_business_id === id : false;
-      const isFrom = kind === 'person' ? raw.from_person_id === id : kind === 'business' ? raw.from_business_id === id : false;
-      const isSubject = kind === 'business' ? raw.subject_business_id === id : kind === 'property' ? raw.subject_property_id === id : false;
-      const isVenue = kind === 'business' ? raw.location_business_id === id : kind === 'property' ? raw.location_property_id === id : false;
-      const value = t.value != null ? parseFloat(t.value) : null;
-
-      const pushEntry = (role, value_direction, counterparty, entryValue) => {
-        const key = `${t.id}:${role}`;
-        if (seen.has(key)) return;
-        seen.add(key);
-        if (counterparty && counterparty.label) counterpartyKeys.add(`${counterparty.type}:${counterparty.id}:${counterparty.label}`);
-        entries.push({
-          transaction_id: t.id,
-          occurred_on: t.occurred_on,
-          transaction_type: t.transaction_type,
-          role,
-          counterparty: counterparty || null,
-          subject: t.resolved_subject,
-          location: t.resolved_location,
-          value: entryValue,
-          currency: t.currency,
-          value_direction,
-          notes: t.notes,
-        });
-      };
-
-      if (isTo) {
-        pushEntry('received', 'in', t.resolved_from, value);
-        if (value != null) { const c = ensureCurrency(t.currency); c.value_in += value; }
-        if (raw.subject_asset_id) pushEntry('acquired_custody', 'in', t.resolved_from, null);
-      }
-      if (isFrom) {
-        pushEntry('gave', 'out', t.resolved_to, value);
-        if (value != null) { const c = ensureCurrency(t.currency); c.value_out += value; }
-        if (raw.subject_asset_id) pushEntry('released_custody', 'out', t.resolved_to, null);
-      }
-      if (isSubject) pushEntry('subject', 'neutral', t.resolved_from || t.resolved_to, value);
-      if (isVenue) pushEntry('venue', 'neutral', t.resolved_from || t.resolved_to, value);
-    }
-
-    entries.sort((a, b) => {
-      const da = a.occurred_on || ''; const db = b.occurred_on || '';
-      if (da === db) return a.transaction_id - b.transaction_id;
-      return da < db ? -1 : 1;
-    });
-
-    const byCurrency = Array.from(byCurrencyMap.values()).map(c => ({ ...c, net: c.value_in - c.value_out }));
-    const totalIn = byCurrency.reduce((s, c) => s + c.value_in, 0);
-    const totalOut = byCurrency.reduce((s, c) => s + c.value_out, 0);
-    const singleCurrency = byCurrency.length <= 1;
+    const { entries, summary } = deriveLedger(kind, id, txResult.rows);
 
     let assetsHeld = [];
     if (kind === 'person') assetsHeld = await currentHoldings('person', id);
@@ -236,15 +144,7 @@ router.get('/:entityType/:id/ledger', requireAuth, validateIdParam, async (req, 
     res.json({
       entity: { type: kind, id, label },
       entries,
-      summary: {
-        value_in: singleCurrency ? totalIn : null,
-        value_out: singleCurrency ? totalOut : null,
-        net: singleCurrency ? totalIn - totalOut : null,
-        by_currency: byCurrency,
-        count_by_type: countByType,
-        distinct_counterparties: counterpartyKeys.size,
-        assets_currently_held: assetsHeld,
-      },
+      summary: { ...summary, assets_currently_held: assetsHeld },
     });
   } catch (err) {
     console.error('Error building ledger:', err);

--- a/backend/routes/locations.js
+++ b/backend/routes/locations.js
@@ -2,7 +2,10 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Get locations with filtering and pagination
 router.get('/', requireAuth, async (req, res) => {
   try {

--- a/backend/routes/people.js
+++ b/backend/routes/people.js
@@ -5,7 +5,10 @@ const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validatePersonData, validateIdParam } = require('../middleware/validation');
 const logAudit = require('../utils/logAudit');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // GET / — paginated people list
 router.get('/', requireAuth, async (req, res) => {
   try {

--- a/backend/routes/properties.js
+++ b/backend/routes/properties.js
@@ -5,9 +5,12 @@ const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
 const { TX_SELECT, decorateTransaction, geocodeFields, deriveCustody, fullName } = require('../utils/transactionHelpers');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
 const OWNERSHIP_TYPES = ['sale', 'purchase', 'transfer', 'acquisition'];
 
+
+router.use(apiLimiter);
 // GET / — list properties
 router.get('/', requireAuth, async (req, res) => {
   try {

--- a/backend/routes/properties.js
+++ b/backend/routes/properties.js
@@ -1,0 +1,189 @@
+// File: backend/routes/properties.js
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+const { validateIdParam } = require('../middleware/validation');
+const { TX_SELECT, decorateTransaction, geocodeFields, deriveCustody, fullName } = require('../utils/transactionHelpers');
+
+const OWNERSHIP_TYPES = ['sale', 'purchase', 'transfer', 'acquisition'];
+
+// GET / — list properties
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 1000);
+    const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+
+    const where = [];
+    const params = [];
+    if (req.query.property_type) { params.push(req.query.property_type); where.push(`p.property_type = $${params.length}`); }
+    if (req.query.case_id) { params.push(parseInt(req.query.case_id, 10)); where.push(`p.case_id = $${params.length}`); }
+    if (req.query.owner_person_id) { params.push(parseInt(req.query.owner_person_id, 10)); where.push(`p.owner_person_id = $${params.length}`); }
+    if (req.query.q) { params.push(`%${req.query.q}%`); where.push(`(p.name ILIKE $${params.length} OR p.address ILIKE $${params.length} OR p.city ILIKE $${params.length})`); }
+    if (req.query.bbox) {
+      const [w, s, e, n] = String(req.query.bbox).split(',').map(Number);
+      if ([w, s, e, n].every(v => !isNaN(v))) {
+        params.push(w, s, e, n);
+        where.push(`p.longitude BETWEEN $${params.length - 3} AND $${params.length - 1} AND p.latitude BETWEEN $${params.length - 2} AND $${params.length}`);
+      }
+    }
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const dataParams = [...params, limit, offset];
+    const dataResult = await pool.query(
+      `SELECT p.*, CONCAT(o.first_name, ' ', COALESCE(o.last_name, '')) AS owner_name
+       FROM properties p
+       LEFT JOIN people o ON p.owner_person_id = o.id
+       ${whereSql}
+       ORDER BY p.created_at DESC
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      dataParams
+    );
+    const countResult = await pool.query(`SELECT COUNT(*)::int AS count FROM properties p ${whereSql}`, params);
+    const total = countResult.rows[0].count;
+
+    res.set('X-Total-Count', String(total));
+    res.set('X-Has-More', String(offset + dataResult.rows.length < total));
+    res.json({ data: dataResult.rows, meta: { total, limit, offset, hasMore: offset + dataResult.rows.length < total } });
+  } catch (err) {
+    console.error('Error fetching properties:', err);
+    res.status(500).json({ error: 'Failed to fetch properties' });
+  }
+});
+
+// POST / — create property
+router.post('/', requireAuth, async (req, res) => {
+  try {
+    const {
+      name, property_type, description, address, city, state, country, postal_code,
+      latitude, longitude, owner_person_id, case_id, notes
+    } = req.body;
+
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'Property name is required' });
+    }
+
+    let geo = { latitude, longitude, geocode_confidence: null, geocode_provider: null, geocoded_at: null, geocode_failure: null };
+    if ((latitude == null || longitude == null) && (address || city || country)) {
+      geo = await geocodeFields(req.app.locals.improvedGeocodingService, { address, city, state, country });
+    }
+
+    const result = await pool.query(
+      `INSERT INTO properties
+        (name, property_type, description, address, city, state, country, postal_code,
+         latitude, longitude, geocode_confidence, geocode_provider, geocoded_at,
+         owner_person_id, case_id, notes)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING *`,
+      [name.trim(), property_type || null, description || null, address || null, city || null,
+       state || null, country || null, postal_code || null, geo.latitude, geo.longitude,
+       geo.geocode_confidence, geo.geocode_provider, geo.geocoded_at,
+       owner_person_id || null, case_id || null, notes || null]
+    );
+    res.status(201).json({ ...result.rows[0], geocode_failure: geo.geocode_failure });
+  } catch (err) {
+    console.error('Error creating property:', err);
+    res.status(500).json({ error: 'Failed to create property' });
+  }
+});
+
+// GET /:id — detail + derived owner + chain of custody + venue transactions
+router.get('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const propResult = await pool.query(
+      `SELECT p.*, CONCAT(o.first_name, ' ', COALESCE(o.last_name, '')) AS owner_name
+       FROM properties p LEFT JOIN people o ON p.owner_person_id = o.id WHERE p.id = $1`, [id]);
+    if (propResult.rows.length === 0) return res.status(404).json({ error: 'Property not found' });
+
+    const subjectTx = await pool.query(
+      `${TX_SELECT} WHERE t.subject_property_id = $1 ORDER BY t.occurred_on ASC NULLS FIRST, t.id ASC`, [id]);
+    const decoratedSubject = subjectTx.rows.map(decorateTransaction);
+    const { currentHolder, since, chain } = deriveCustody(decoratedSubject, OWNERSHIP_TYPES);
+
+    const venueTx = await pool.query(
+      `${TX_SELECT} WHERE t.location_property_id = $1 ORDER BY t.occurred_on DESC NULLS LAST, t.id DESC`, [id]);
+
+    res.json({
+      ...propResult.rows[0],
+      derived_current_owner: currentHolder,
+      derived_owner_since: since,
+      chain_of_custody: chain,
+      venue_transactions: venueTx.rows.map(decorateTransaction),
+    });
+  } catch (err) {
+    console.error('Error fetching property:', err);
+    res.status(500).json({ error: 'Failed to fetch property' });
+  }
+});
+
+// PUT /:id — update
+router.put('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const existing = await pool.query('SELECT * FROM properties WHERE id = $1', [id]);
+    if (existing.rows.length === 0) return res.status(404).json({ error: 'Property not found' });
+
+    const {
+      name, property_type, description, address, city, state, country, postal_code,
+      latitude, longitude, owner_person_id, case_id, notes
+    } = req.body;
+
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'Property name is required' });
+    }
+
+    let geo = { latitude, longitude, geocode_confidence: existing.rows[0].geocode_confidence, geocode_provider: existing.rows[0].geocode_provider, geocoded_at: existing.rows[0].geocoded_at, geocode_failure: null };
+    if ((latitude == null || longitude == null) && (address || city || country)) {
+      geo = await geocodeFields(req.app.locals.improvedGeocodingService, { address, city, state, country });
+    }
+
+    const result = await pool.query(
+      `UPDATE properties SET
+         name=$1, property_type=$2, description=$3, address=$4, city=$5, state=$6, country=$7,
+         postal_code=$8, latitude=$9, longitude=$10, geocode_confidence=$11, geocode_provider=$12,
+         geocoded_at=$13, owner_person_id=$14, case_id=$15, notes=$16, updated_at=CURRENT_TIMESTAMP
+       WHERE id=$17 RETURNING *`,
+      [name.trim(), property_type || null, description || null, address || null, city || null,
+       state || null, country || null, postal_code || null, geo.latitude, geo.longitude,
+       geo.geocode_confidence, geo.geocode_provider, geo.geocoded_at,
+       owner_person_id || null, case_id || null, notes || null, id]
+    );
+    res.json({ ...result.rows[0], geocode_failure: geo.geocode_failure });
+  } catch (err) {
+    console.error('Error updating property:', err);
+    res.status(500).json({ error: 'Failed to update property' });
+  }
+});
+
+// DELETE /:id
+router.delete('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const result = await pool.query('DELETE FROM properties WHERE id = $1 RETURNING *', [req.params.id]);
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Property not found' });
+    res.json({ message: 'Property deleted successfully' });
+  } catch (err) {
+    console.error('Error deleting property:', err);
+    res.status(500).json({ error: 'Failed to delete property' });
+  }
+});
+
+// GET /:id/transactions — subject | venue (flag role)
+router.get('/:id/transactions', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const id = req.params.id;
+    const result = await pool.query(
+      `${TX_SELECT} WHERE t.subject_property_id = $1 OR t.location_property_id = $1
+       ORDER BY t.occurred_on DESC NULLS LAST, t.id DESC`, [id]);
+    const rows = result.rows.map(r => {
+      const d = decorateTransaction(r);
+      d.role = r.subject_property_id === id ? 'subject' : 'venue';
+      return d;
+    });
+    res.json({ data: rows, meta: { total: rows.length } });
+  } catch (err) {
+    console.error('Error fetching property transactions:', err);
+    res.status(500).json({ error: 'Failed to fetch property transactions' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -2,7 +2,10 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Universal search
 router.get('/', requireAuth, async (req, res) => {
   const { q } = req.query;

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth, requireAdmin } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Custom fields
 router.get('/custom-fields', requireAdmin, async (req, res) => {
   try {

--- a/backend/routes/todos.js
+++ b/backend/routes/todos.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 router.get('/', requireAuth, async (req, res) => {
   try {
     const result = await pool.query('SELECT * FROM todos ORDER BY created_at DESC');

--- a/backend/routes/tools.js
+++ b/backend/routes/tools.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateToolData, validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 router.get('/', requireAuth, async (req, res) => {
   try {
     const result = await pool.query('SELECT * FROM tools ORDER BY name ASC');

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -4,21 +4,10 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
-const { TX_SELECT, decorateTransaction, geocodeFields } = require('../utils/transactionHelpers');
-
-const FROM_REFS = ['from_person_id', 'from_business_id', 'from_external'];
-const TO_REFS = ['to_person_id', 'to_business_id', 'to_external'];
-const SUBJECT_REFS = ['subject_asset_id', 'subject_business_id', 'subject_property_id'];
-const LOCATION_REFS = ['location_business_id', 'location_property_id'];
-
-function countSet(body, keys) {
-  return keys.filter(k => body[k] !== undefined && body[k] !== null && body[k] !== '').length;
-}
-function isPositiveIntOrNull(v) {
-  if (v === undefined || v === null || v === '') return true;
-  const n = Number(v);
-  return Number.isInteger(n) && n > 0;
-}
+const {
+  TX_SELECT, decorateTransaction, geocodeFields,
+  SUBJECT_REFS, LOCATION_REFS, countSet, validateTransactionShape,
+} = require('../utils/transactionHelpers');
 
 async function validateTransaction(body) {
   if (!body.transaction_type || typeof body.transaction_type !== 'string' || !body.transaction_type.trim()) {
@@ -28,27 +17,7 @@ async function validateTransaction(body) {
     `SELECT 1 FROM model_options WHERE model_type = 'transaction_type' AND option_value = $1 AND is_active = TRUE`,
     [body.transaction_type]);
   if (typeCheck.rows.length === 0) return `Unknown transaction_type: ${body.transaction_type}`;
-
-  if (countSet(body, FROM_REFS) === 0 && countSet(body, TO_REFS) === 0) {
-    return 'At least one party (from_* or to_*) is required';
-  }
-  if (countSet(body, FROM_REFS) > 1) return 'Only one giver (from_*) may be set';
-  if (countSet(body, TO_REFS) > 1) return 'Only one receiver (to_*) may be set';
-  if (countSet(body, SUBJECT_REFS) > 1) return 'Only one referenced subject may be set';
-  if (countSet(body, LOCATION_REFS) > 1) return 'Only one event location reference may be set';
-
-  for (const k of [...FROM_REFS.slice(0, 2), ...TO_REFS.slice(0, 2), ...SUBJECT_REFS, ...LOCATION_REFS,
-                   'case_id']) {
-    if (!isPositiveIntOrNull(body[k])) return `${k} must be a positive integer`;
-  }
-  if (body.value != null && body.value !== '' && (isNaN(Number(body.value)) || Number(body.value) < 0)) {
-    return 'value must be a non-negative number';
-  }
-  if (body.occurred_on) {
-    const d = new Date(body.occurred_on);
-    if (isNaN(d.getTime())) return 'occurred_on is not a valid date';
-  }
-  return null;
+  return validateTransactionShape(body);
 }
 
 // Normalise the body: a referenced subject clears free-text item_label (§5.3).

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -1,0 +1,206 @@
+// File: backend/routes/transactions.js
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+const { validateIdParam } = require('../middleware/validation');
+const { TX_SELECT, decorateTransaction, geocodeFields } = require('../utils/transactionHelpers');
+
+const FROM_REFS = ['from_person_id', 'from_business_id', 'from_external'];
+const TO_REFS = ['to_person_id', 'to_business_id', 'to_external'];
+const SUBJECT_REFS = ['subject_asset_id', 'subject_business_id', 'subject_property_id'];
+const LOCATION_REFS = ['location_business_id', 'location_property_id'];
+
+function countSet(body, keys) {
+  return keys.filter(k => body[k] !== undefined && body[k] !== null && body[k] !== '').length;
+}
+function isPositiveIntOrNull(v) {
+  if (v === undefined || v === null || v === '') return true;
+  const n = Number(v);
+  return Number.isInteger(n) && n > 0;
+}
+
+async function validateTransaction(body) {
+  if (!body.transaction_type || typeof body.transaction_type !== 'string' || !body.transaction_type.trim()) {
+    return 'transaction_type is required';
+  }
+  const typeCheck = await pool.query(
+    `SELECT 1 FROM model_options WHERE model_type = 'transaction_type' AND option_value = $1 AND is_active = TRUE`,
+    [body.transaction_type]);
+  if (typeCheck.rows.length === 0) return `Unknown transaction_type: ${body.transaction_type}`;
+
+  if (countSet(body, FROM_REFS) === 0 && countSet(body, TO_REFS) === 0) {
+    return 'At least one party (from_* or to_*) is required';
+  }
+  if (countSet(body, FROM_REFS) > 1) return 'Only one giver (from_*) may be set';
+  if (countSet(body, TO_REFS) > 1) return 'Only one receiver (to_*) may be set';
+  if (countSet(body, SUBJECT_REFS) > 1) return 'Only one referenced subject may be set';
+  if (countSet(body, LOCATION_REFS) > 1) return 'Only one event location reference may be set';
+
+  for (const k of [...FROM_REFS.slice(0, 2), ...TO_REFS.slice(0, 2), ...SUBJECT_REFS, ...LOCATION_REFS,
+                   'case_id']) {
+    if (!isPositiveIntOrNull(body[k])) return `${k} must be a positive integer`;
+  }
+  if (body.value != null && body.value !== '' && (isNaN(Number(body.value)) || Number(body.value) < 0)) {
+    return 'value must be a non-negative number';
+  }
+  if (body.occurred_on) {
+    const d = new Date(body.occurred_on);
+    if (isNaN(d.getTime())) return 'occurred_on is not a valid date';
+  }
+  return null;
+}
+
+// Normalise the body: a referenced subject clears free-text item_label (§5.3).
+function normaliseSubject(body) {
+  if (countSet(body, SUBJECT_REFS) > 0) {
+    body.item_label = null;
+  }
+}
+
+// GET / — list with filters
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 1000);
+    const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+    const q = req.query;
+    const where = [];
+    const params = [];
+    const add = (cond, ...vals) => { vals.forEach(v => params.push(v)); where.push(cond); };
+
+    if (q.transaction_type) add(`t.transaction_type = $${params.length + 1}`, q.transaction_type);
+    if (q.item_category) add(`t.item_category = $${params.length + 1}`, q.item_category);
+    if (q.from_person_id) add(`t.from_person_id = $${params.length + 1}`, parseInt(q.from_person_id, 10));
+    if (q.to_person_id) add(`t.to_person_id = $${params.length + 1}`, parseInt(q.to_person_id, 10));
+    if (q.person_id) {
+      const v = parseInt(q.person_id, 10);
+      add(`(t.from_person_id = $${params.length + 1} OR t.to_person_id = $${params.length + 1})`, v);
+    }
+    if (q.business_id) {
+      const v = parseInt(q.business_id, 10);
+      add(`(t.from_business_id = $${params.length + 1} OR t.to_business_id = $${params.length + 1} OR t.subject_business_id = $${params.length + 1} OR t.location_business_id = $${params.length + 1})`, v);
+    }
+    if (q.subject_asset_id) add(`t.subject_asset_id = $${params.length + 1}`, parseInt(q.subject_asset_id, 10));
+    if (q.subject_business_id) add(`t.subject_business_id = $${params.length + 1}`, parseInt(q.subject_business_id, 10));
+    if (q.subject_property_id) add(`t.subject_property_id = $${params.length + 1}`, parseInt(q.subject_property_id, 10));
+    if (q.location_business_id) add(`t.location_business_id = $${params.length + 1}`, parseInt(q.location_business_id, 10));
+    if (q.location_property_id) add(`t.location_property_id = $${params.length + 1}`, parseInt(q.location_property_id, 10));
+    if (q.case_id) add(`t.case_id = $${params.length + 1}`, parseInt(q.case_id, 10));
+    if (q.date_from) add(`t.occurred_on >= $${params.length + 1}`, q.date_from);
+    if (q.date_to) add(`t.occurred_on <= $${params.length + 1}`, q.date_to);
+    if (q.bbox) {
+      const [w, s, e, n] = String(q.bbox).split(',').map(Number);
+      if ([w, s, e, n].every(v => !isNaN(v))) {
+        params.push(w, s, e, n);
+        where.push(`t.longitude BETWEEN $${params.length - 3} AND $${params.length - 1} AND t.latitude BETWEEN $${params.length - 2} AND $${params.length}`);
+      }
+    }
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const dataResult = await pool.query(
+      `${TX_SELECT} ${whereSql} ORDER BY t.occurred_on DESC NULLS LAST, t.id DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]);
+    const countResult = await pool.query(`SELECT COUNT(*)::int AS count FROM transactions t ${whereSql}`, params);
+    const total = countResult.rows[0].count;
+    const data = dataResult.rows.map(decorateTransaction);
+
+    res.set('X-Total-Count', String(total));
+    res.set('X-Has-More', String(offset + data.length < total));
+    res.json({ data, meta: { total, limit, offset, hasMore: offset + data.length < total } });
+  } catch (err) {
+    console.error('Error fetching transactions:', err);
+    res.status(500).json({ error: 'Failed to fetch transactions' });
+  }
+});
+
+const TX_COLUMNS = [
+  'transaction_type', 'item_label', 'item_category', 'subject_asset_id', 'subject_business_id', 'subject_property_id',
+  'from_person_id', 'from_business_id', 'from_external', 'to_person_id', 'to_business_id', 'to_external',
+  'value', 'currency', 'occurred_on', 'location_business_id', 'location_property_id', 'location_name',
+  'address', 'city', 'state', 'country', 'postal_code', 'latitude', 'longitude',
+  'geocode_confidence', 'geocode_provider', 'geocoded_at', 'case_id', 'notes',
+];
+
+function buildValues(body, geo) {
+  return TX_COLUMNS.map(col => {
+    if (['latitude', 'longitude', 'geocode_confidence', 'geocode_provider', 'geocoded_at'].includes(col)) return geo[col];
+    const v = body[col];
+    return v === undefined || v === '' ? null : v;
+  });
+}
+
+// POST /
+router.post('/', requireAuth, async (req, res) => {
+  const err = await validateTransaction(req.body);
+  if (err) return res.status(400).json({ error: err });
+  normaliseSubject(req.body);
+  try {
+    let geo = { latitude: req.body.latitude || null, longitude: req.body.longitude || null, geocode_confidence: null, geocode_provider: null, geocoded_at: null, geocode_failure: null };
+    const hasRefLocation = countSet(req.body, LOCATION_REFS) > 0;
+    if (!hasRefLocation && (req.body.latitude == null || req.body.longitude == null) && (req.body.address || req.body.city || req.body.country)) {
+      geo = await geocodeFields(req.app.locals.improvedGeocodingService, req.body);
+    }
+    const placeholders = TX_COLUMNS.map((_, i) => `$${i + 1}`).join(', ');
+    const result = await pool.query(
+      `INSERT INTO transactions (${TX_COLUMNS.join(', ')}) VALUES (${placeholders}) RETURNING id`,
+      buildValues(req.body, geo));
+    const full = await pool.query(`${TX_SELECT} WHERE t.id = $1`, [result.rows[0].id]);
+    res.status(201).json({ ...decorateTransaction(full.rows[0]), geocode_failure: geo.geocode_failure });
+  } catch (e) {
+    console.error('Error creating transaction:', e);
+    res.status(500).json({ error: 'Failed to create transaction' });
+  }
+});
+
+// GET /:id
+router.get('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const result = await pool.query(`${TX_SELECT} WHERE t.id = $1`, [req.params.id]);
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Transaction not found' });
+    res.json(decorateTransaction(result.rows[0]));
+  } catch (err) {
+    console.error('Error fetching transaction:', err);
+    res.status(500).json({ error: 'Failed to fetch transaction' });
+  }
+});
+
+// PUT /:id
+router.put('/:id', requireAuth, validateIdParam, async (req, res) => {
+  const err = await validateTransaction(req.body);
+  if (err) return res.status(400).json({ error: err });
+  normaliseSubject(req.body);
+  try {
+    const existing = await pool.query('SELECT * FROM transactions WHERE id = $1', [req.params.id]);
+    if (existing.rows.length === 0) return res.status(404).json({ error: 'Transaction not found' });
+
+    let geo = { latitude: req.body.latitude || null, longitude: req.body.longitude || null, geocode_confidence: existing.rows[0].geocode_confidence, geocode_provider: existing.rows[0].geocode_provider, geocoded_at: existing.rows[0].geocoded_at, geocode_failure: null };
+    const hasRefLocation = countSet(req.body, LOCATION_REFS) > 0;
+    if (!hasRefLocation && (req.body.latitude == null || req.body.longitude == null) && (req.body.address || req.body.city || req.body.country)) {
+      geo = await geocodeFields(req.app.locals.improvedGeocodingService, req.body);
+    }
+    const setSql = TX_COLUMNS.map((col, i) => `${col} = $${i + 1}`).join(', ');
+    const values = buildValues(req.body, geo);
+    values.push(req.params.id);
+    await pool.query(
+      `UPDATE transactions SET ${setSql}, updated_at = CURRENT_TIMESTAMP WHERE id = $${values.length}`, values);
+    const full = await pool.query(`${TX_SELECT} WHERE t.id = $1`, [req.params.id]);
+    res.json({ ...decorateTransaction(full.rows[0]), geocode_failure: geo.geocode_failure });
+  } catch (e) {
+    console.error('Error updating transaction:', e);
+    res.status(500).json({ error: 'Failed to update transaction' });
+  }
+});
+
+// DELETE /:id
+router.delete('/:id', requireAuth, validateIdParam, async (req, res) => {
+  try {
+    const result = await pool.query('DELETE FROM transactions WHERE id = $1 RETURNING *', [req.params.id]);
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Transaction not found' });
+    res.json({ message: 'Transaction deleted successfully' });
+  } catch (err) {
+    console.error('Error deleting transaction:', err);
+    res.status(500).json({ error: 'Failed to delete transaction' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -4,6 +4,9 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
+
+router.use(apiLimiter);
 const {
   TX_SELECT, decorateTransaction, geocodeFields,
   SUBJECT_REFS, LOCATION_REFS, countSet, validateTransactionShape,

--- a/backend/routes/travelHistory.js
+++ b/backend/routes/travelHistory.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const { pool } = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Get travel history for a person
 router.get('/people/:id/travel-history', requireAuth, validateIdParam, async (req, res) => {
   const personId = req.params.id;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -6,7 +6,10 @@ const { pool } = require('../config/database');
 const { requireAdmin, requireAuth } = require('../middleware/auth');
 const { validatePasswordStrength } = require('../utils/passwordPolicy');
 const { revokeSessionsForUser } = require('../utils/sessions');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // Get all users (admin only)
 router.get('/', requireAdmin, async (req, res) => {
   try {

--- a/backend/routes/wirelessNetworks.js
+++ b/backend/routes/wirelessNetworks.js
@@ -6,7 +6,10 @@ const xml2js = require('xml2js');
 const { pool } = require('../config/database');
 const { requireAuth, requireAdmin } = require('../middleware/auth');
 const { validateIdParam } = require('../middleware/validation');
+const { apiLimiter } = require('../middleware/rateLimiters');
 
+
+router.use(apiLimiter);
 // -------------------------------------------------------------------------
 // IMPORTANT: /stats, /nearby, and /bulk-delete MUST be defined BEFORE /:id
 // to avoid Express treating "stats", "nearby", "bulk-delete" as an :id param.

--- a/backend/server.js
+++ b/backend/server.js
@@ -326,7 +326,59 @@ const initializeDatabase = async () => {
       { model_type: 'location_type', option_value: 'work', option_label: 'Work', display_order: 3 },
       { model_type: 'location_type', option_value: 'favorite_hotel', option_label: 'Favorite Hotel', display_order: 4 },
       { model_type: 'location_type', option_value: 'yacht_location', option_label: 'Yacht Location', display_order: 5 },
-      { model_type: 'location_type', option_value: 'other', option_label: 'Other', display_order: 6 }
+      { model_type: 'location_type', option_value: 'other', option_label: 'Other', display_order: 6 },
+
+      // Transaction types
+      { model_type: 'transaction_type', option_value: 'gift',       option_label: 'Gift',                  display_order: 1 },
+      { model_type: 'transaction_type', option_value: 'donation',   option_label: 'Donation',              display_order: 2 },
+      { model_type: 'transaction_type', option_value: 'benefit',    option_label: 'Benefit / Hospitality', display_order: 3 },
+      { model_type: 'transaction_type', option_value: 'sale',       option_label: 'Sale',                  display_order: 4 },
+      { model_type: 'transaction_type', option_value: 'purchase',   option_label: 'Purchase',              display_order: 5 },
+      { model_type: 'transaction_type', option_value: 'transfer',   option_label: 'Transfer',              display_order: 6 },
+      { model_type: 'transaction_type', option_value: 'assignment', option_label: 'Assignment',            display_order: 7 },
+      { model_type: 'transaction_type', option_value: 'return',     option_label: 'Returned',              display_order: 8 },
+      { model_type: 'transaction_type', option_value: 'loan',       option_label: 'Loan / Borrowed',       display_order: 9 },
+      { model_type: 'transaction_type', option_value: 'acquisition',option_label: 'Acquisition',           display_order: 10 },
+      { model_type: 'transaction_type', option_value: 'lost',       option_label: 'Lost',                  display_order: 11 },
+      { model_type: 'transaction_type', option_value: 'seized',     option_label: 'Seized',                display_order: 12 },
+      { model_type: 'transaction_type', option_value: 'visit',      option_label: 'Visit / Attendance',    display_order: 13 },
+      { model_type: 'transaction_type', option_value: 'other',      option_label: 'Other',                 display_order: 14 },
+
+      // Transaction item categories
+      { model_type: 'transaction_item_category', option_value: 'cash_donation',    option_label: 'Cash / Donation',    display_order: 1 },
+      { model_type: 'transaction_item_category', option_value: 'hospitality',      option_label: 'Hospitality / Meal', display_order: 2 },
+      { model_type: 'transaction_item_category', option_value: 'tickets_event',    option_label: 'Tickets / Event',    display_order: 3 },
+      { model_type: 'transaction_item_category', option_value: 'travel',           option_label: 'Travel',             display_order: 4 },
+      { model_type: 'transaction_item_category', option_value: 'real_estate',      option_label: 'Real Estate',        display_order: 5 },
+      { model_type: 'transaction_item_category', option_value: 'business_interest',option_label: 'Business Interest',  display_order: 6 },
+      { model_type: 'transaction_item_category', option_value: 'physical_good',    option_label: 'Physical Good',      display_order: 7 },
+      { model_type: 'transaction_item_category', option_value: 'other',            option_label: 'Other',              display_order: 8 },
+
+      // Asset categories
+      { model_type: 'asset_category', option_value: 'watch',           option_label: 'Watch',           display_order: 1 },
+      { model_type: 'asset_category', option_value: 'jewellery',       option_label: 'Jewellery',       display_order: 2 },
+      { model_type: 'asset_category', option_value: 'electronics',     option_label: 'Electronics',     display_order: 3 },
+      { model_type: 'asset_category', option_value: 'laptop',          option_label: 'Laptop / Device', display_order: 4 },
+      { model_type: 'asset_category', option_value: 'vehicle',         option_label: 'Vehicle',         display_order: 5 },
+      { model_type: 'asset_category', option_value: 'tracking_device', option_label: 'Tracking Device', display_order: 6 },
+      { model_type: 'asset_category', option_value: 'document',        option_label: 'Document',        display_order: 7 },
+      { model_type: 'asset_category', option_value: 'other',           option_label: 'Other',           display_order: 8 },
+
+      // Asset statuses
+      { model_type: 'asset_status', option_value: 'active',    option_label: 'Active',    display_order: 1 },
+      { model_type: 'asset_status', option_value: 'lost',      option_label: 'Lost',      display_order: 2 },
+      { model_type: 'asset_status', option_value: 'destroyed', option_label: 'Destroyed', display_order: 3 },
+      { model_type: 'asset_status', option_value: 'seized',    option_label: 'Seized',    display_order: 4 },
+      { model_type: 'asset_status', option_value: 'disposed',  option_label: 'Disposed',  display_order: 5 },
+
+      // Property types
+      { model_type: 'property_type', option_value: 'parcel',          option_label: 'Parcel / Lot',    display_order: 1 },
+      { model_type: 'property_type', option_value: 'residential',     option_label: 'Residential',     display_order: 2 },
+      { model_type: 'property_type', option_value: 'rental',          option_label: 'Rental Property', display_order: 3 },
+      { model_type: 'property_type', option_value: 'commercial',      option_label: 'Commercial',      display_order: 4 },
+      { model_type: 'property_type', option_value: 'land',            option_label: 'Land',            display_order: 5 },
+      { model_type: 'property_type', option_value: 'development_site', option_label: 'Development Site',display_order: 6 },
+      { model_type: 'property_type', option_value: 'other',           option_label: 'Other',           display_order: 7 }
     ];
 
     for (const option of defaultOptions) {
@@ -541,6 +593,139 @@ const initializeDatabase = async () => {
     `);
     console.log('Backfilled wireless_networks.associated_person_ids from person_id.');
 
+    // ── Transaction tracking feature (issue #43): properties → assets → transactions ──
+    // FK create order matters: transactions references all three; assets references nothing new.
+
+    // Create properties table (real estate / parcels / land / venues)
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS properties (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        property_type VARCHAR(100),
+        description TEXT,
+        address TEXT,
+        city VARCHAR(100),
+        state VARCHAR(100),
+        country VARCHAR(100),
+        postal_code VARCHAR(20),
+        latitude DECIMAL(10, 8),
+        longitude DECIMAL(11, 8),
+        geocode_confidence INTEGER,
+        geocode_provider VARCHAR(50),
+        geocoded_at TIMESTAMPTZ,
+        owner_person_id INTEGER REFERENCES people(id) ON DELETE SET NULL,
+        case_id INTEGER REFERENCES cases(id) ON DELETE SET NULL,
+        notes TEXT,
+        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    console.log('Checked/created "properties" table.');
+    await applyUpdatedAtTrigger(client, 'properties');
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_properties_owner ON properties(owner_person_id);
+      CREATE INDEX IF NOT EXISTS idx_properties_case ON properties(case_id);
+      CREATE INDEX IF NOT EXISTS idx_properties_location ON properties(latitude, longitude);
+      CREATE INDEX IF NOT EXISTS idx_properties_country_city ON properties(country, city);
+    `);
+
+    // Create assets table (persistent physical goods with custody/location model)
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS assets (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        category VARCHAR(100),
+        identifier VARCHAR(255),
+        description TEXT,
+        notes TEXT,
+        estimated_value DECIMAL(14, 2),
+        currency VARCHAR(10),
+        status VARCHAR(50) DEFAULT 'active',
+        location_mode VARCHAR(20) DEFAULT 'with_holder',
+        location_person_id INTEGER REFERENCES people(id) ON DELETE SET NULL,
+        location_ref VARCHAR(255),
+        location_name VARCHAR(255),
+        address TEXT,
+        city VARCHAR(100),
+        state VARCHAR(100),
+        country VARCHAR(100),
+        postal_code VARCHAR(20),
+        latitude DECIMAL(10, 8),
+        longitude DECIMAL(11, 8),
+        geocode_confidence INTEGER,
+        geocode_provider VARCHAR(50),
+        geocoded_at TIMESTAMPTZ,
+        case_id INTEGER REFERENCES cases(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    console.log('Checked/created "assets" table.');
+    await applyUpdatedAtTrigger(client, 'assets');
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_assets_category ON assets(category);
+      CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status);
+      CREATE INDEX IF NOT EXISTS idx_assets_case ON assets(case_id);
+      CREATE INDEX IF NOT EXISTS idx_assets_location_person ON assets(location_person_id);
+      CREATE INDEX IF NOT EXISTS idx_assets_coords ON assets(latitude, longitude);
+    `);
+
+    // Create transactions table (event log: gifts, donations, sales, transfers, custody…)
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS transactions (
+        id SERIAL PRIMARY KEY,
+        transaction_type VARCHAR(50) NOT NULL,
+        item_label VARCHAR(255),
+        item_category VARCHAR(100),
+        subject_asset_id INTEGER REFERENCES assets(id) ON DELETE SET NULL,
+        subject_business_id INTEGER REFERENCES businesses(id) ON DELETE SET NULL,
+        subject_property_id INTEGER REFERENCES properties(id) ON DELETE SET NULL,
+        from_person_id INTEGER REFERENCES people(id) ON DELETE SET NULL,
+        from_business_id INTEGER REFERENCES businesses(id) ON DELETE SET NULL,
+        from_external VARCHAR(255),
+        to_person_id INTEGER REFERENCES people(id) ON DELETE SET NULL,
+        to_business_id INTEGER REFERENCES businesses(id) ON DELETE SET NULL,
+        to_external VARCHAR(255),
+        value DECIMAL(14, 2),
+        currency VARCHAR(10),
+        occurred_on DATE,
+        location_business_id INTEGER REFERENCES businesses(id) ON DELETE SET NULL,
+        location_property_id INTEGER REFERENCES properties(id) ON DELETE SET NULL,
+        location_name VARCHAR(255),
+        address TEXT,
+        city VARCHAR(100),
+        state VARCHAR(100),
+        country VARCHAR(100),
+        postal_code VARCHAR(20),
+        latitude DECIMAL(10, 8),
+        longitude DECIMAL(11, 8),
+        geocode_confidence INTEGER,
+        geocode_provider VARCHAR(50),
+        geocoded_at TIMESTAMPTZ,
+        case_id INTEGER REFERENCES cases(id) ON DELETE SET NULL,
+        notes TEXT,
+        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    console.log('Checked/created "transactions" table.');
+    await applyUpdatedAtTrigger(client, 'transactions');
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_transactions_type ON transactions(transaction_type);
+      CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions(occurred_on);
+      CREATE INDEX IF NOT EXISTS idx_transactions_from_person ON transactions(from_person_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_to_person ON transactions(to_person_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_from_business ON transactions(from_business_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_to_business ON transactions(to_business_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_subject_asset ON transactions(subject_asset_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_subject_business ON transactions(subject_business_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_subject_property ON transactions(subject_property_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_location_business ON transactions(location_business_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_location_property ON transactions(location_property_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_case ON transactions(case_id);
+      CREATE INDEX IF NOT EXISTS idx_transactions_coords ON transactions(latitude, longitude);
+    `);
+
   } catch (err) {
     console.error('Error during database initialization:', err.stack);
     process.exit(1);
@@ -609,6 +794,10 @@ const todosRoutes = require('./routes/todos');
 const toolsRoutes = require('./routes/tools');
 const travelHistoryRoutes = require('./routes/travelHistory');
 const wirelessNetworksRoutes = require('./routes/wirelessNetworks');
+const propertiesRoutes = require('./routes/properties');
+const assetsRoutes = require('./routes/assets');
+const transactionsRoutes = require('./routes/transactions');
+const ledgerRoutes = require('./routes/ledger');
 
 app.use('/api/auth', authRoutes);
 app.use('/api/users', usersRoutes);
@@ -625,6 +814,10 @@ app.use('/api/todos', todosRoutes);
 app.use('/api/tools', toolsRoutes);
 app.use('/api', travelHistoryRoutes);
 app.use('/api/wireless-networks', wirelessNetworksRoutes);
+app.use('/api/properties', propertiesRoutes);
+app.use('/api/assets', assetsRoutes);
+app.use('/api/transactions', transactionsRoutes);
+app.use('/api', ledgerRoutes);
 
 app.get('/api', (req, res) => {
   res.json({ message: "Hello from the OSINT CRM Backend!" });

--- a/backend/utils/transactionHelpers.js
+++ b/backend/utils/transactionHelpers.js
@@ -159,8 +159,150 @@ function deriveCustody(orderedTxns, ownershipTypes) {
   return { currentHolder, since, chain };
 }
 
+// Pure venue-stats aggregation from raw joined transaction rows (location_business_id = id).
+function aggregateVenueStats(rawRows) {
+  const peopleMap = new Map();
+  const byType = {};
+  let firstEvent = null, lastEvent = null;
+  const decorated = rawRows.map(decorateTransaction);
+  decorated.forEach(t => {
+    byType[t.transaction_type] = (byType[t.transaction_type] || 0) + 1;
+    if (t.occurred_on) {
+      const d = t.occurred_on instanceof Date ? t.occurred_on.toISOString().slice(0, 10) : String(t.occurred_on);
+      if (!firstEvent || d < firstEvent) firstEvent = d;
+      if (!lastEvent || d > lastEvent) lastEvent = d;
+    }
+    [t.resolved_from, t.resolved_to].forEach(party => {
+      if (party && party.type === 'person' && party.id) {
+        const cur = peopleMap.get(party.id) || { id: party.id, label: party.label, event_count: 0 };
+        cur.event_count += 1;
+        peopleMap.set(party.id, cur);
+      }
+    });
+  });
+  const people = Array.from(peopleMap.values()).sort((a, b) => b.event_count - a.event_count);
+  return { event_count: decorated.length, distinct_people: people.length, people, first_event: firstEvent, last_event: lastEvent, by_type: byType };
+}
+
+// Pure ledger derivation (entries + summary) for an entity from raw joined rows.
+// kind ∈ 'person'|'business'|'property'. assets_currently_held is added by the caller.
+function deriveLedger(kind, id, rawRows) {
+  const entries = [];
+  const seen = new Set();
+  const counterpartyKeys = new Set();
+  const countByType = {};
+  const byCurrencyMap = new Map();
+  const ensureCurrency = (cur) => {
+    const c = cur || 'UNSPEC';
+    if (!byCurrencyMap.has(c)) byCurrencyMap.set(c, { currency: cur || null, value_in: 0, value_out: 0, net: 0 });
+    return byCurrencyMap.get(c);
+  };
+
+  rawRows.forEach(raw => {
+    const t = decorateTransaction(raw);
+    countByType[t.transaction_type] = (countByType[t.transaction_type] || 0) + 1;
+    const isTo = kind === 'person' ? raw.to_person_id === id : kind === 'business' ? raw.to_business_id === id : false;
+    const isFrom = kind === 'person' ? raw.from_person_id === id : kind === 'business' ? raw.from_business_id === id : false;
+    const isSubject = kind === 'business' ? raw.subject_business_id === id : kind === 'property' ? raw.subject_property_id === id : false;
+    const isVenue = kind === 'business' ? raw.location_business_id === id : kind === 'property' ? raw.location_property_id === id : false;
+    const value = t.value != null ? parseFloat(t.value) : null;
+
+    const pushEntry = (role, value_direction, counterparty, entryValue) => {
+      const key = `${t.id}:${role}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      if (counterparty && counterparty.label) counterpartyKeys.add(`${counterparty.type}:${counterparty.id}:${counterparty.label}`);
+      entries.push({
+        transaction_id: t.id, occurred_on: t.occurred_on, transaction_type: t.transaction_type,
+        role, counterparty: counterparty || null, subject: t.resolved_subject, location: t.resolved_location,
+        value: entryValue, currency: t.currency, value_direction, notes: t.notes,
+      });
+    };
+
+    if (isTo) {
+      pushEntry('received', 'in', t.resolved_from, value);
+      if (value != null) ensureCurrency(t.currency).value_in += value;
+      if (raw.subject_asset_id) pushEntry('acquired_custody', 'in', t.resolved_from, null);
+    }
+    if (isFrom) {
+      pushEntry('gave', 'out', t.resolved_to, value);
+      if (value != null) ensureCurrency(t.currency).value_out += value;
+      if (raw.subject_asset_id) pushEntry('released_custody', 'out', t.resolved_to, null);
+    }
+    if (isSubject) pushEntry('subject', 'neutral', t.resolved_from || t.resolved_to, value);
+    if (isVenue) pushEntry('venue', 'neutral', t.resolved_from || t.resolved_to, value);
+  });
+
+  entries.sort((a, b) => {
+    const da = a.occurred_on || ''; const db = b.occurred_on || '';
+    if (da === db) return a.transaction_id - b.transaction_id;
+    return da < db ? -1 : 1;
+  });
+
+  const byCurrency = Array.from(byCurrencyMap.values()).map(c => ({ ...c, net: c.value_in - c.value_out }));
+  const totalIn = byCurrency.reduce((s, c) => s + c.value_in, 0);
+  const totalOut = byCurrency.reduce((s, c) => s + c.value_out, 0);
+  const singleCurrency = byCurrency.length <= 1;
+
+  return {
+    entries,
+    summary: {
+      value_in: singleCurrency ? totalIn : null,
+      value_out: singleCurrency ? totalOut : null,
+      net: singleCurrency ? totalIn - totalOut : null,
+      by_currency: byCurrency,
+      count_by_type: countByType,
+      distinct_counterparties: counterpartyKeys.size,
+    },
+  };
+}
+
+// Pure validation of transaction body shape (§5 rules 2-5). The transaction_type
+// required + active-option check stays in the route (needs DB). Returns error string or null.
+const FROM_REFS = ['from_person_id', 'from_business_id', 'from_external'];
+const TO_REFS = ['to_person_id', 'to_business_id', 'to_external'];
+const SUBJECT_REFS = ['subject_asset_id', 'subject_business_id', 'subject_property_id'];
+const LOCATION_REFS = ['location_business_id', 'location_property_id'];
+
+function countSet(body, keys) {
+  return keys.filter(k => body[k] !== undefined && body[k] !== null && body[k] !== '').length;
+}
+function isPositiveIntOrNull(v) {
+  if (v === undefined || v === null || v === '') return true;
+  const n = Number(v);
+  return Number.isInteger(n) && n > 0;
+}
+
+function validateTransactionShape(body) {
+  if (countSet(body, FROM_REFS) === 0 && countSet(body, TO_REFS) === 0) {
+    return 'At least one party (from_* or to_*) is required';
+  }
+  if (countSet(body, FROM_REFS) > 1) return 'Only one giver (from_*) may be set';
+  if (countSet(body, TO_REFS) > 1) return 'Only one receiver (to_*) may be set';
+  if (countSet(body, SUBJECT_REFS) > 1) return 'Only one referenced subject may be set';
+  if (countSet(body, LOCATION_REFS) > 1) return 'Only one event location reference may be set';
+  for (const k of [...FROM_REFS.slice(0, 2), ...TO_REFS.slice(0, 2), ...SUBJECT_REFS, ...LOCATION_REFS, 'case_id']) {
+    if (!isPositiveIntOrNull(body[k])) return `${k} must be a positive integer`;
+  }
+  if (body.value != null && body.value !== '' && (isNaN(Number(body.value)) || Number(body.value) < 0)) {
+    return 'value must be a non-negative number';
+  }
+  if (body.occurred_on) {
+    const d = new Date(body.occurred_on);
+    if (isNaN(d.getTime())) return 'occurred_on is not a valid date';
+  }
+  return null;
+}
+
 module.exports = {
   TX_SELECT,
+  FROM_REFS,
+  TO_REFS,
+  SUBJECT_REFS,
+  LOCATION_REFS,
+  countSet,
+  isPositiveIntOrNull,
+  validateTransactionShape,
   fullName,
   resolveParty,
   resolveSubject,
@@ -168,4 +310,6 @@ module.exports = {
   decorateTransaction,
   geocodeFields,
   deriveCustody,
+  aggregateVenueStats,
+  deriveLedger,
 };

--- a/backend/utils/transactionHelpers.js
+++ b/backend/utils/transactionHelpers.js
@@ -1,0 +1,171 @@
+// File: backend/utils/transactionHelpers.js
+// Shared helpers for the transaction-tracking feature (issue #43):
+// resolved party/subject/location decoration, geocoding, and a custody resolver.
+
+// SELECT fragment for transactions with all label/coordinate joins.
+// Append a WHERE / ORDER BY clause when using it.
+const TX_SELECT = `
+  SELECT t.*,
+    fp.first_name AS from_person_first, fp.last_name AS from_person_last,
+    fb.name AS from_business_name,
+    tp.first_name AS to_person_first, tp.last_name AS to_person_last,
+    tb.name AS to_business_name,
+    sa.name AS subject_asset_name,
+    sb.name AS subject_business_name,
+    sp.name AS subject_property_name,
+    lb.name AS location_business_name, lb.latitude AS location_business_lat, lb.longitude AS location_business_lng,
+    lp.name AS location_property_name, lp.latitude AS location_property_lat, lp.longitude AS location_property_lng
+  FROM transactions t
+  LEFT JOIN people     fp ON t.from_person_id     = fp.id
+  LEFT JOIN businesses fb ON t.from_business_id   = fb.id
+  LEFT JOIN people     tp ON t.to_person_id       = tp.id
+  LEFT JOIN businesses tb ON t.to_business_id     = tb.id
+  LEFT JOIN assets     sa ON t.subject_asset_id   = sa.id
+  LEFT JOIN businesses sb ON t.subject_business_id= sb.id
+  LEFT JOIN properties sp ON t.subject_property_id= sp.id
+  LEFT JOIN businesses lb ON t.location_business_id  = lb.id
+  LEFT JOIN properties lp ON t.location_property_id  = lp.id
+`;
+
+function fullName(first, last) {
+  return [first, last].filter(Boolean).join(' ').trim();
+}
+
+function resolveParty(row, dir) {
+  // dir is 'from' or 'to'
+  const personId = row[`${dir}_person_id`];
+  const businessId = row[`${dir}_business_id`];
+  const external = row[`${dir}_external`];
+  if (personId) {
+    return { type: 'person', id: personId, label: fullName(row[`${dir}_person_first`], row[`${dir}_person_last`]) || `Person #${personId}` };
+  }
+  if (businessId) {
+    return { type: 'business', id: businessId, label: row[`${dir}_business_name`] || `Business #${businessId}` };
+  }
+  if (external) {
+    return { type: 'external', id: null, label: external };
+  }
+  return null;
+}
+
+function resolveSubject(row) {
+  if (row.subject_asset_id) {
+    return { type: 'asset', id: row.subject_asset_id, label: row.subject_asset_name || `Asset #${row.subject_asset_id}` };
+  }
+  if (row.subject_business_id) {
+    return { type: 'business', id: row.subject_business_id, label: row.subject_business_name || `Business #${row.subject_business_id}` };
+  }
+  if (row.subject_property_id) {
+    return { type: 'property', id: row.subject_property_id, label: row.subject_property_name || `Property #${row.subject_property_id}` };
+  }
+  if (row.item_label) {
+    return { type: 'item', id: null, label: row.item_label, category: row.item_category || null };
+  }
+  return { type: 'item', id: null, label: null, category: row.item_category || null };
+}
+
+function resolveLocation(row) {
+  if (row.location_business_id) {
+    return {
+      type: 'business', id: row.location_business_id, label: row.location_business_name || `Business #${row.location_business_id}`,
+      latitude: row.location_business_lat != null ? parseFloat(row.location_business_lat) : null,
+      longitude: row.location_business_lng != null ? parseFloat(row.location_business_lng) : null,
+    };
+  }
+  if (row.location_property_id) {
+    return {
+      type: 'property', id: row.location_property_id, label: row.location_property_name || `Property #${row.location_property_id}`,
+      latitude: row.location_property_lat != null ? parseFloat(row.location_property_lat) : null,
+      longitude: row.location_property_lng != null ? parseFloat(row.location_property_lng) : null,
+    };
+  }
+  if (row.location_name || row.latitude || row.address || row.city) {
+    return {
+      type: 'place', id: null, label: row.location_name || [row.city, row.country].filter(Boolean).join(', ') || null,
+      latitude: row.latitude != null ? parseFloat(row.latitude) : null,
+      longitude: row.longitude != null ? parseFloat(row.longitude) : null,
+    };
+  }
+  return { type: 'none', id: null, label: null, latitude: null, longitude: null };
+}
+
+// Strip the joined helper columns and attach resolved objects.
+function decorateTransaction(row) {
+  const resolved_from = resolveParty(row, 'from');
+  const resolved_to = resolveParty(row, 'to');
+  const resolved_subject = resolveSubject(row);
+  const resolved_location = resolveLocation(row);
+
+  const clean = { ...row };
+  // remove join-only helper columns
+  [
+    'from_person_first', 'from_person_last', 'from_business_name',
+    'to_person_first', 'to_person_last', 'to_business_name',
+    'subject_asset_name', 'subject_business_name', 'subject_property_name',
+    'location_business_name', 'location_business_lat', 'location_business_lng',
+    'location_property_name', 'location_property_lat', 'location_property_lng',
+  ].forEach(k => delete clean[k]);
+
+  return { ...clean, resolved_from, resolved_to, resolved_subject, resolved_location };
+}
+
+// Geocode free-text address fields. Non-fatal: returns coords or a failure reason.
+async function geocodeFields(service, fields) {
+  const parts = [fields.address, fields.city, fields.state, fields.country].filter(Boolean);
+  if (!service || parts.length === 0) {
+    return { latitude: null, longitude: null, geocode_confidence: null, geocode_provider: null, geocoded_at: null, geocode_failure: parts.length === 0 ? 'empty' : 'service_error' };
+  }
+  try {
+    const result = await service.geocodeAddress(parts.join(', '), { minConfidence: 30 });
+    if (result && !result.failure) {
+      return {
+        latitude: result.lat,
+        longitude: result.lng,
+        geocode_confidence: result.confidence != null ? Math.round(result.confidence) : null,
+        geocode_provider: result.provider || null,
+        geocoded_at: new Date(),
+        geocode_failure: null,
+      };
+    }
+    return { latitude: null, longitude: null, geocode_confidence: null, geocode_provider: null, geocoded_at: null, geocode_failure: (result && result.failure) || 'not_found' };
+  } catch (err) {
+    console.error('geocodeFields error:', err.message);
+    return { latitude: null, longitude: null, geocode_confidence: null, geocode_provider: null, geocoded_at: null, geocode_failure: 'service_error' };
+  }
+}
+
+// Given an ordered (occurred_on ASC, id ASC) list of decorated transactions for a
+// single subject, return { currentHolder, chain }. ownershipTypes optionally limits
+// which transaction types count as a change of ownership (for businesses/properties).
+function deriveCustody(orderedTxns, ownershipTypes) {
+  const chain = orderedTxns.map(t => ({
+    transaction_id: t.id,
+    occurred_on: t.occurred_on,
+    transaction_type: t.transaction_type,
+    from: t.resolved_from,
+    to: t.resolved_to,
+    value: t.value,
+    currency: t.currency,
+  }));
+  let currentHolder = null;
+  let since = null;
+  for (const t of orderedTxns) {
+    if (ownershipTypes && !ownershipTypes.includes(t.transaction_type)) continue;
+    if (t.resolved_to) {
+      currentHolder = t.resolved_to;
+      since = t.occurred_on;
+    }
+  }
+  return { currentHolder, since, chain };
+}
+
+module.exports = {
+  TX_SELECT,
+  fullName,
+  resolveParty,
+  resolveSubject,
+  resolveLocation,
+  decorateTransaction,
+  geocodeFields,
+  deriveCustody,
+};

--- a/backend/utils/transactionHelpers.test.js
+++ b/backend/utils/transactionHelpers.test.js
@@ -1,0 +1,232 @@
+const {
+  resolveParty,
+  resolveSubject,
+  resolveLocation,
+  decorateTransaction,
+  geocodeFields,
+  deriveCustody,
+  aggregateVenueStats,
+  deriveLedger,
+  validateTransactionShape,
+} = require('./transactionHelpers');
+
+// ── validateTransactionShape (§5 rules) ─────────────────────────────────────
+
+describe('validateTransactionShape', () => {
+  test('accepts a minimal valid transaction', () => {
+    expect(validateTransactionShape({ to_person_id: 1 })).toBeNull();
+  });
+  test('rejects no party', () => {
+    expect(validateTransactionShape({})).toMatch(/at least one party/i);
+  });
+  test('rejects two givers', () => {
+    expect(validateTransactionShape({ from_person_id: 1, from_business_id: 2 })).toMatch(/one giver/i);
+  });
+  test('rejects two subject references', () => {
+    expect(validateTransactionShape({ to_person_id: 1, subject_asset_id: 1, subject_business_id: 2 })).toMatch(/one referenced subject/i);
+  });
+  test('rejects two location references', () => {
+    expect(validateTransactionShape({ to_person_id: 1, location_business_id: 1, location_property_id: 2 })).toMatch(/one event location/i);
+  });
+  test('rejects negative value', () => {
+    expect(validateTransactionShape({ to_person_id: 1, value: -5 })).toMatch(/non-negative/i);
+  });
+  test('rejects invalid date', () => {
+    expect(validateTransactionShape({ to_person_id: 1, occurred_on: 'not-a-date' })).toMatch(/valid date/i);
+  });
+  test('rejects non-positive FK id', () => {
+    expect(validateTransactionShape({ to_person_id: -3 })).toMatch(/positive integer/i);
+  });
+});
+
+// ── resolveParty ────────────────────────────────────────────────────────────
+
+describe('resolveParty', () => {
+  test('resolves a person party', () => {
+    const row = { from_person_id: 7, from_person_first: 'Jane', from_person_last: 'Roe' };
+    expect(resolveParty(row, 'from')).toEqual({ type: 'person', id: 7, label: 'Jane Roe' });
+  });
+  test('resolves a business party', () => {
+    const row = { to_business_id: 5, to_business_name: 'Bistro X' };
+    expect(resolveParty(row, 'to')).toEqual({ type: 'business', id: 5, label: 'Bistro X' });
+  });
+  test('resolves an external party', () => {
+    expect(resolveParty({ from_external: 'Acme Corp' }, 'from')).toEqual({ type: 'external', id: null, label: 'Acme Corp' });
+  });
+  test('returns null when no party set', () => {
+    expect(resolveParty({}, 'from')).toBeNull();
+  });
+});
+
+// ── resolveSubject ──────────────────────────────────────────────────────────
+
+describe('resolveSubject', () => {
+  test('asset subject wins over item label', () => {
+    const s = resolveSubject({ subject_asset_id: 3, subject_asset_name: 'Rolex', item_label: 'ignore' });
+    expect(s).toEqual({ type: 'asset', id: 3, label: 'Rolex' });
+  });
+  test('free-text item subject', () => {
+    const s = resolveSubject({ item_label: 'Dinner', item_category: 'hospitality' });
+    expect(s).toEqual({ type: 'item', id: null, label: 'Dinner', category: 'hospitality' });
+  });
+});
+
+// ── resolveLocation ─────────────────────────────────────────────────────────
+
+describe('resolveLocation', () => {
+  test('business venue location', () => {
+    const l = resolveLocation({ location_business_id: 5, location_business_name: 'Bistro X', location_business_lat: '1.5', location_business_lng: '2.5' });
+    expect(l).toEqual({ type: 'business', id: 5, label: 'Bistro X', latitude: 1.5, longitude: 2.5 });
+  });
+  test('free-text place location', () => {
+    const l = resolveLocation({ location_name: 'Park', latitude: '10', longitude: '20' });
+    expect(l.type).toBe('place');
+    expect(l.latitude).toBe(10);
+  });
+  test('none when no location', () => {
+    expect(resolveLocation({}).type).toBe('none');
+  });
+});
+
+// ── decorateTransaction ─────────────────────────────────────────────────────
+
+describe('decorateTransaction', () => {
+  test('attaches resolved fields and strips join columns', () => {
+    const row = {
+      id: 1, transaction_type: 'gift',
+      from_person_id: 7, from_person_first: 'Jane', from_person_last: 'Roe',
+      to_business_id: 5, to_business_name: 'Bistro X',
+      item_label: 'Tickets',
+    };
+    const d = decorateTransaction(row);
+    expect(d.resolved_from.label).toBe('Jane Roe');
+    expect(d.resolved_to.label).toBe('Bistro X');
+    expect(d.resolved_subject.label).toBe('Tickets');
+    expect(d.from_person_first).toBeUndefined();
+    expect(d.to_business_name).toBeUndefined();
+  });
+});
+
+// ── deriveCustody ───────────────────────────────────────────────────────────
+
+describe('deriveCustody', () => {
+  const mk = (id, type, occurred, to) => ({
+    id, transaction_type: type, occurred_on: occurred,
+    resolved_from: null, resolved_to: to, value: null, currency: null,
+  });
+
+  test('current holder is the latest to_ party', () => {
+    const txns = [
+      mk(1, 'acquisition', '2025-01-01', { type: 'person', id: 1, label: 'A' }),
+      mk(2, 'transfer', '2025-06-01', { type: 'person', id: 2, label: 'B' }),
+    ];
+    const { currentHolder, chain } = deriveCustody(txns);
+    expect(currentHolder.label).toBe('B');
+    expect(chain).toHaveLength(2);
+  });
+
+  test('ownershipTypes filter ignores non-ownership transactions', () => {
+    const txns = [
+      mk(1, 'sale', '2025-01-01', { type: 'person', id: 1, label: 'A' }),
+      mk(2, 'visit', '2025-06-01', { type: 'person', id: 9, label: 'Visitor' }),
+    ];
+    const { currentHolder } = deriveCustody(txns, ['sale', 'purchase', 'transfer', 'acquisition']);
+    expect(currentHolder.label).toBe('A');
+  });
+});
+
+// ── geocodeFields ───────────────────────────────────────────────────────────
+
+describe('geocodeFields', () => {
+  test('returns coords on success', async () => {
+    const service = { geocodeAddress: async () => ({ lat: 1.1, lng: 2.2, confidence: 80, provider: 'nominatim' }) };
+    const r = await geocodeFields(service, { city: 'Paris', country: 'France' });
+    expect(r.latitude).toBe(1.1);
+    expect(r.geocode_confidence).toBe(80);
+    expect(r.geocode_failure).toBeNull();
+  });
+  test('returns failure reason when geocoding fails', async () => {
+    const service = { geocodeAddress: async () => ({ failure: 'not_found' }) };
+    const r = await geocodeFields(service, { city: 'Nowhere' });
+    expect(r.latitude).toBeNull();
+    expect(r.geocode_failure).toBe('not_found');
+  });
+  test('empty when no address parts', async () => {
+    const r = await geocodeFields({ geocodeAddress: async () => ({}) }, {});
+    expect(r.geocode_failure).toBe('empty');
+  });
+});
+
+// ── aggregateVenueStats ─────────────────────────────────────────────────────
+
+describe('aggregateVenueStats', () => {
+  test('counts distinct people and ranks by event count', () => {
+    const rows = [
+      { id: 1, transaction_type: 'benefit', occurred_on: '2025-01-01', to_person_id: 1, to_person_first: 'A', to_person_last: '' },
+      { id: 2, transaction_type: 'benefit', occurred_on: '2025-02-01', to_person_id: 1, to_person_first: 'A', to_person_last: '' },
+      { id: 3, transaction_type: 'visit', occurred_on: '2025-03-01', to_person_id: 2, to_person_first: 'B', to_person_last: '' },
+    ];
+    const stats = aggregateVenueStats(rows);
+    expect(stats.event_count).toBe(3);
+    expect(stats.distinct_people).toBe(2);
+    expect(stats.people[0].id).toBe(1);
+    expect(stats.people[0].event_count).toBe(2);
+    expect(stats.by_type).toEqual({ benefit: 2, visit: 1 });
+    expect(stats.first_event).toBe('2025-01-01');
+    expect(stats.last_event).toBe('2025-03-01');
+  });
+});
+
+// ── deriveLedger ────────────────────────────────────────────────────────────
+
+describe('deriveLedger', () => {
+  test('person received: value_in and received role', () => {
+    const rows = [{
+      id: 1, transaction_type: 'benefit', occurred_on: '2025-03-04',
+      to_person_id: 12, from_business_id: 5, from_business_name: 'Bistro X',
+      item_label: 'Dinner', value: '100.00', currency: 'USD',
+    }];
+    const { entries, summary } = deriveLedger('person', 12, rows);
+    expect(entries[0].role).toBe('received');
+    expect(entries[0].value_direction).toBe('in');
+    expect(entries[0].counterparty.label).toBe('Bistro X');
+    expect(summary.value_in).toBe(100);
+    expect(summary.value_out).toBe(0);
+    expect(summary.net).toBe(100);
+    expect(summary.distinct_counterparties).toBe(1);
+  });
+
+  test('person gave with asset subject emits gave + released_custody', () => {
+    const rows = [{
+      id: 2, transaction_type: 'transfer', occurred_on: '2025-04-01',
+      from_person_id: 12, to_person_id: 13, to_person_first: 'B', to_person_last: '',
+      subject_asset_id: 3, subject_asset_name: 'Rolex',
+    }];
+    const { entries, summary } = deriveLedger('person', 12, rows);
+    const roles = entries.map(e => e.role);
+    expect(roles).toContain('gave');
+    expect(roles).toContain('released_custody');
+    expect(summary.value_out).toBe(0);
+  });
+
+  test('mixed currencies produce null net and by_currency breakdown', () => {
+    const rows = [
+      { id: 1, transaction_type: 'donation', occurred_on: '2025-01-01', to_person_id: 1, value: '100', currency: 'USD' },
+      { id: 2, transaction_type: 'donation', occurred_on: '2025-02-01', to_person_id: 1, value: '50', currency: 'EUR' },
+    ];
+    const { summary } = deriveLedger('person', 1, rows);
+    expect(summary.net).toBeNull();
+    expect(summary.by_currency).toHaveLength(2);
+  });
+
+  test('business as venue gets a neutral venue entry', () => {
+    const rows = [{
+      id: 9, transaction_type: 'benefit', occurred_on: '2025-05-01',
+      location_business_id: 5, from_business_id: 8, from_business_name: 'Host', to_person_id: 1, to_person_first: 'P', to_person_last: '',
+      value: '40', currency: 'USD',
+    }];
+    const { entries } = deriveLedger('business', 5, rows);
+    expect(entries[0].role).toBe('venue');
+    expect(entries[0].value_direction).toBe('neutral');
+  });
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import 'reactflow/dist/style.css';
-import { Home, Users, Wrench, Network, Settings, Shield, Map, Folder, Search, Building2, Wifi, LogOut } from 'lucide-react';
+import { Home, Users, Wrench, Network, Settings, Shield, Map, Folder, Search, Building2, Wifi, LogOut, Landmark, Package, Receipt } from 'lucide-react';
 
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { DataProvider, useData } from './contexts/DataContext';
@@ -25,6 +25,16 @@ import AddEditBusinessForm from './components/AddEditBusinessForm';
 import DarkModeToggle from './components/DarkModeToggle';
 import SystemHealth from './components/SystemHealth';
 import WirelessNetworks from './components/WirelessNetworks';
+import PropertyList from './components/PropertyList';
+import AddEditPropertyForm from './components/AddEditPropertyForm';
+import PropertyDetailModal from './components/PropertyDetailModal';
+import AssetsList from './components/AssetsList';
+import AddEditAssetForm from './components/AddEditAssetForm';
+import AssetDetailModal from './components/AssetDetailModal';
+import TransactionsList from './components/TransactionsList';
+import AddEditTransactionForm from './components/AddEditTransactionForm';
+import TransactionDetailModal from './components/TransactionDetailModal';
+import BusinessDetailModal from './components/BusinessDetailModal';
 import Login from './components/Login';
 
 // Fix default Leaflet marker icons
@@ -40,6 +50,9 @@ const navigationItems = [
   { id: 'cases',         label: 'Cases',              icon: Folder },
   { id: 'people',        label: 'People',             icon: Users },
   { id: 'businesses',    label: 'Businesses',         icon: Building2 },
+  { id: 'properties',    label: 'Properties',         icon: Landmark },
+  { id: 'assets',        label: 'Assets',             icon: Package },
+  { id: 'transactions',  label: 'Transactions',       icon: Receipt },
   { id: 'tools',         label: 'OSINT Tools',        icon: Wrench },
   { id: 'relationships', label: 'Entity Network',     icon: Network },
   { id: 'map',           label: 'Locations',          icon: Map },
@@ -61,6 +74,16 @@ const AppShell = () => {
     showAddToolForm, setShowAddToolForm,
     editingBusiness, setEditingBusiness,
     showAddBusinessForm, setShowAddBusinessForm,
+    selectedPropertyForDetail, setSelectedPropertyForDetail,
+    editingProperty, setEditingProperty,
+    showAddPropertyForm, setShowAddPropertyForm,
+    selectedAssetForDetail, setSelectedAssetForDetail,
+    editingAsset, setEditingAsset,
+    showAddAssetForm, setShowAddAssetForm,
+    selectedTransactionForDetail, setSelectedTransactionForDetail,
+    editingTransaction, setEditingTransaction,
+    showAddTransactionForm, setShowAddTransactionForm,
+    selectedBusinessForDetail, setSelectedBusinessForDetail,
     showAdvancedSearch, setShowAdvancedSearch,
   } = useUI();
 
@@ -175,6 +198,9 @@ const AppShell = () => {
               {activeSection === 'people'        && <PeopleList />}
               {activeSection === 'tools'         && <ToolsList />}
               {activeSection === 'businesses'    && <BusinessList />}
+              {activeSection === 'properties'    && <PropertyList />}
+              {activeSection === 'assets'        && <AssetsList />}
+              {activeSection === 'transactions'  && <TransactionsList />}
               {activeSection === 'map'           && <div className="h-full"><GlobalMap /></div>}
               {activeSection === 'wireless'      && <div className="h-full"><WirelessNetworks /></div>}
               {activeSection === 'settings'      && <SettingsPage />}
@@ -206,6 +232,24 @@ const AppShell = () => {
       {editingTool        && <AddEditToolForm tool={editingTool} onSave={() => { setEditingTool(null); }} onCancel={() => setEditingTool(null)} />}
       {showAddBusinessForm && <AddEditBusinessForm business={null} onSave={() => { setShowAddBusinessForm(false); }} onCancel={() => setShowAddBusinessForm(false)} />}
       {editingBusiness    && <AddEditBusinessForm business={editingBusiness} onSave={() => { setEditingBusiness(null); }} onCancel={() => setEditingBusiness(null)} />}
+
+      {/* Property modals */}
+      {showAddPropertyForm && <AddEditPropertyForm property={null} onClose={() => setShowAddPropertyForm(false)} />}
+      {editingProperty     && <AddEditPropertyForm property={editingProperty} onClose={() => setEditingProperty(null)} />}
+      {selectedPropertyForDetail && <PropertyDetailModal property={selectedPropertyForDetail} onClose={() => setSelectedPropertyForDetail(null)} />}
+
+      {/* Asset modals */}
+      {showAddAssetForm && <AddEditAssetForm asset={null} onClose={() => setShowAddAssetForm(false)} />}
+      {editingAsset     && <AddEditAssetForm asset={editingAsset} onClose={() => setEditingAsset(null)} />}
+      {selectedAssetForDetail && <AssetDetailModal asset={selectedAssetForDetail} onClose={() => setSelectedAssetForDetail(null)} />}
+
+      {/* Transaction modals */}
+      {showAddTransactionForm && <AddEditTransactionForm transaction={null} onClose={() => setShowAddTransactionForm(false)} />}
+      {editingTransaction     && <AddEditTransactionForm transaction={editingTransaction} onClose={() => setEditingTransaction(null)} />}
+      {selectedTransactionForDetail && <TransactionDetailModal transaction={selectedTransactionForDetail} onClose={() => setSelectedTransactionForDetail(null)} />}
+
+      {/* Business detail (venue activity / ledger) */}
+      {selectedBusinessForDetail && <BusinessDetailModal business={selectedBusinessForDetail} onClose={() => setSelectedBusinessForDetail(null)} />}
       {showAdvancedSearch && (
         <AdvancedSearch
           onSelectPerson={(person) => { setSelectedPersonForDetail(person); setShowAdvancedSearch(false); }}

--- a/frontend/src/components/AddEditAssetForm.js
+++ b/frontend/src/components/AddEditAssetForm.js
@@ -1,0 +1,225 @@
+// File: frontend/src/components/AddEditAssetForm.js
+import React, { useState, useEffect } from 'react';
+import { X, Package } from 'lucide-react';
+import { assetsAPI, modelOptionsAPI, casesAPI } from '../utils/api';
+import { useData } from '../contexts/DataContext';
+
+const inputClass = 'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 dark:bg-gray-700 dark:text-white';
+const labelClass = 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1';
+
+const LOCATION_MODES = [
+  { value: 'with_holder', label: 'With current holder (moves automatically)' },
+  { value: 'fixed_known', label: 'Pinned to a person\'s known location' },
+  { value: 'fixed_custom', label: 'Fixed custom address' },
+  { value: 'unknown', label: 'Unknown' },
+];
+
+const AddEditAssetForm = ({ asset, onClose }) => {
+  const { people, businesses, fetchAssets } = useData();
+  const isEdit = !!asset;
+  const [categoryOptions, setCategoryOptions] = useState([]);
+  const [statusOptions, setStatusOptions] = useState([]);
+  const [cases, setCases] = useState([]);
+  const [personLocations, setPersonLocations] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const [form, setForm] = useState({
+    name: asset?.name || '',
+    category: asset?.category || '',
+    identifier: asset?.identifier || '',
+    description: asset?.description || '',
+    estimated_value: asset?.estimated_value || '',
+    currency: asset?.currency || '',
+    status: asset?.status || 'active',
+    notes: asset?.notes || '',
+    case_id: asset?.case_id || '',
+    location_mode: asset?.location_mode || 'with_holder',
+    location_person_id: asset?.location_person_id || '',
+    location_ref: asset?.location_ref || '',
+    address: asset?.address || '',
+    city: asset?.city || '',
+    state: asset?.state || '',
+    country: asset?.country || '',
+    postal_code: asset?.postal_code || '',
+    latitude: asset?.latitude || '',
+    longitude: asset?.longitude || '',
+  });
+
+  // initial holder (create only)
+  const [holderKind, setHolderKind] = useState('none');
+  const [holderId, setHolderId] = useState('');
+  const [holderExternal, setHolderExternal] = useState('');
+  const [holderDate, setHolderDate] = useState('');
+
+  useEffect(() => {
+    modelOptionsAPI.getAll().then(d => {
+      setCategoryOptions(d.filter(o => o.model_type === 'asset_category' && o.is_active));
+      setStatusOptions(d.filter(o => o.model_type === 'asset_status' && o.is_active));
+    }).catch(() => {});
+    casesAPI.getAll().then(setCases).catch(() => {});
+  }, []);
+
+  // when fixed_known person changes, load their locations from the people slice
+  useEffect(() => {
+    if (form.location_mode === 'fixed_known' && form.location_person_id) {
+      const p = people.find(pp => String(pp.id) === String(form.location_person_id));
+      setPersonLocations(Array.isArray(p?.locations) ? p.locations : []);
+    } else {
+      setPersonLocations([]);
+    }
+  }, [form.location_mode, form.location_person_id, people]);
+
+  const update = (k, v) => setForm(prev => ({ ...prev, [k]: v }));
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name.trim()) { setError('Name is required'); return; }
+    if (form.location_mode === 'fixed_known' && !form.location_person_id) { setError('Pick a person for the pinned location'); return; }
+    setSaving(true);
+    setError('');
+    const payload = {
+      ...form,
+      estimated_value: form.estimated_value === '' ? null : parseFloat(form.estimated_value),
+      latitude: form.latitude === '' ? null : parseFloat(form.latitude),
+      longitude: form.longitude === '' ? null : parseFloat(form.longitude),
+      location_person_id: form.location_person_id || null,
+      location_ref: form.location_ref === '' ? null : form.location_ref,
+      case_id: form.case_id || null,
+    };
+    if (!isEdit && holderKind !== 'none') {
+      payload.initial_holder = {
+        person_id: holderKind === 'person' ? holderId || null : null,
+        business_id: holderKind === 'business' ? holderId || null : null,
+        external: holderKind === 'external' ? holderExternal || null : null,
+        occurred_on: holderDate || null,
+      };
+    }
+    try {
+      if (isEdit) await assetsAPI.update(asset.id, payload);
+      else await assetsAPI.create(payload);
+      await fetchAssets(0);
+      onClose();
+    } catch (err) {
+      setError(err.message || 'Failed to save asset');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center">
+            <Package className="w-5 h-5 mr-2 text-orange-600 dark:text-orange-400" />{isEdit ? 'Edit Asset' : 'Add Asset'}
+          </h2>
+          <button onClick={onClose} className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700"><X className="w-5 h-5" /></button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
+          {error && <div className="p-3 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-sm">{error}</div>}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="col-span-2"><label className={labelClass}>Name *</label><input className={inputClass} value={form.name} onChange={e => update('name', e.target.value)} /></div>
+            <div><label className={labelClass}>Category</label>
+              <select className={inputClass} value={form.category} onChange={e => update('category', e.target.value)}>
+                <option value="">— Select —</option>
+                {categoryOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+              </select>
+            </div>
+            <div><label className={labelClass}>Status</label>
+              <select className={inputClass} value={form.status} onChange={e => update('status', e.target.value)}>
+                {statusOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+              </select>
+            </div>
+            <div><label className={labelClass}>Identifier (serial / VIN / IMEI)</label><input className={inputClass} value={form.identifier} onChange={e => update('identifier', e.target.value)} /></div>
+            <div className="grid grid-cols-2 gap-2">
+              <div><label className={labelClass}>Est. Value</label><input className={inputClass} value={form.estimated_value} onChange={e => update('estimated_value', e.target.value)} /></div>
+              <div><label className={labelClass}>Currency</label><input className={inputClass} value={form.currency} onChange={e => update('currency', e.target.value)} placeholder="USD" /></div>
+            </div>
+            <div className="col-span-2"><label className={labelClass}>Description</label><textarea className={inputClass} rows={2} value={form.description} onChange={e => update('description', e.target.value)} /></div>
+          </div>
+
+          {/* Location model */}
+          <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-3">
+            <div><label className={labelClass}>Location Mode</label>
+              <select className={inputClass} value={form.location_mode} onChange={e => update('location_mode', e.target.value)}>
+                {LOCATION_MODES.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
+              </select>
+            </div>
+            {form.location_mode === 'fixed_known' && (
+              <div className="grid grid-cols-2 gap-3">
+                <div><label className={labelClass}>Person</label>
+                  <select className={inputClass} value={form.location_person_id} onChange={e => { update('location_person_id', e.target.value); update('location_ref', ''); }}>
+                    <option value="">— Select —</option>
+                    {people.map(p => <option key={p.id} value={p.id}>{`${p.first_name || ''} ${p.last_name || ''}`.trim()}</option>)}
+                  </select>
+                </div>
+                <div><label className={labelClass}>Location entry</label>
+                  <select className={inputClass} value={form.location_ref} onChange={e => update('location_ref', e.target.value)}>
+                    <option value="">— Select —</option>
+                    {personLocations.map((loc, idx) => <option key={idx} value={idx}>{(loc.type || loc.location_type || 'location') + ': ' + (loc.location_name || loc.address || [loc.city, loc.country].filter(Boolean).join(', ') || `#${idx}`)}</option>)}
+                  </select>
+                </div>
+              </div>
+            )}
+            {form.location_mode === 'fixed_custom' && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="col-span-2"><label className={labelClass}>Address</label><input className={inputClass} value={form.address} onChange={e => update('address', e.target.value)} /></div>
+                <div><label className={labelClass}>City</label><input className={inputClass} value={form.city} onChange={e => update('city', e.target.value)} /></div>
+                <div><label className={labelClass}>Country</label><input className={inputClass} value={form.country} onChange={e => update('country', e.target.value)} /></div>
+                <div><label className={labelClass}>Latitude</label><input className={inputClass} value={form.latitude} onChange={e => update('latitude', e.target.value)} placeholder="auto-geocoded if blank" /></div>
+                <div><label className={labelClass}>Longitude</label><input className={inputClass} value={form.longitude} onChange={e => update('longitude', e.target.value)} /></div>
+              </div>
+            )}
+          </div>
+
+          {/* Initial holder (create only) */}
+          {!isEdit && (
+            <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-3">
+              <label className={labelClass}>Initial Holder (seeds an acquisition transaction)</label>
+              <div className="grid grid-cols-2 gap-3">
+                <select className={inputClass} value={holderKind} onChange={e => { setHolderKind(e.target.value); setHolderId(''); }}>
+                  <option value="none">— None —</option>
+                  <option value="person">Person</option>
+                  <option value="business">Business</option>
+                  <option value="external">External (free text)</option>
+                </select>
+                {holderKind === 'person' && (
+                  <select className={inputClass} value={holderId} onChange={e => setHolderId(e.target.value)}>
+                    <option value="">— Select —</option>
+                    {people.map(p => <option key={p.id} value={p.id}>{`${p.first_name || ''} ${p.last_name || ''}`.trim()}</option>)}
+                  </select>
+                )}
+                {holderKind === 'business' && (
+                  <select className={inputClass} value={holderId} onChange={e => setHolderId(e.target.value)}>
+                    <option value="">— Select —</option>
+                    {businesses.map(bz => <option key={bz.id} value={bz.id}>{bz.name}</option>)}
+                  </select>
+                )}
+                {holderKind === 'external' && <input className={inputClass} value={holderExternal} onChange={e => setHolderExternal(e.target.value)} placeholder="External holder name" />}
+              </div>
+              {holderKind !== 'none' && <div><label className={labelClass}>Acquired on</label><input type="date" className={inputClass} value={holderDate} onChange={e => setHolderDate(e.target.value)} /></div>}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            <div><label className={labelClass}>Case</label>
+              <select className={inputClass} value={form.case_id} onChange={e => update('case_id', e.target.value)}>
+                <option value="">— None —</option>
+                {cases.map(c => <option key={c.id} value={c.id}>{c.case_name}</option>)}
+              </select>
+            </div>
+            <div className="col-span-2"><label className={labelClass}>Notes</label><textarea className={inputClass} rows={2} value={form.notes} onChange={e => update('notes', e.target.value)} /></div>
+          </div>
+
+          <div className="flex justify-end space-x-3 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Cancel</button>
+            <button type="submit" disabled={saving} className="px-4 py-2 rounded-lg bg-blue-600 text-white disabled:opacity-60">{saving ? 'Saving…' : 'Save'}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddEditAssetForm;

--- a/frontend/src/components/AddEditPropertyForm.js
+++ b/frontend/src/components/AddEditPropertyForm.js
@@ -1,0 +1,131 @@
+// File: frontend/src/components/AddEditPropertyForm.js
+import React, { useState, useEffect } from 'react';
+import { X, Landmark } from 'lucide-react';
+import { propertiesAPI, modelOptionsAPI, casesAPI } from '../utils/api';
+import { useData } from '../contexts/DataContext';
+
+const inputClass = 'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 dark:bg-gray-700 dark:text-white';
+const labelClass = 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1';
+
+const AddEditPropertyForm = ({ property, onClose }) => {
+  const { people, fetchProperties } = useData();
+  const isEdit = !!property;
+  const [typeOptions, setTypeOptions] = useState([]);
+  const [cases, setCases] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState({
+    name: property?.name || '',
+    property_type: property?.property_type || '',
+    description: property?.description || '',
+    address: property?.address || '',
+    city: property?.city || '',
+    state: property?.state || '',
+    country: property?.country || '',
+    postal_code: property?.postal_code || '',
+    latitude: property?.latitude || '',
+    longitude: property?.longitude || '',
+    owner_person_id: property?.owner_person_id || '',
+    case_id: property?.case_id || '',
+    notes: property?.notes || '',
+  });
+
+  useEffect(() => {
+    modelOptionsAPI.getAll().then(d => setTypeOptions(d.filter(o => o.model_type === 'property_type' && o.is_active))).catch(() => {});
+    casesAPI.getAll().then(setCases).catch(() => {});
+  }, []);
+
+  const update = (k, v) => setForm(prev => ({ ...prev, [k]: v }));
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name.trim()) { setError('Name is required'); return; }
+    setSaving(true);
+    setError('');
+    const payload = {
+      ...form,
+      latitude: form.latitude === '' ? null : parseFloat(form.latitude),
+      longitude: form.longitude === '' ? null : parseFloat(form.longitude),
+      owner_person_id: form.owner_person_id || null,
+      case_id: form.case_id || null,
+    };
+    try {
+      if (isEdit) await propertiesAPI.update(property.id, payload);
+      else await propertiesAPI.create(payload);
+      await fetchProperties(0);
+      onClose();
+    } catch (err) {
+      setError(err.message || 'Failed to save property');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center">
+            <Landmark className="w-5 h-5 mr-2 text-emerald-600 dark:text-emerald-400" />
+            {isEdit ? 'Edit Property' : 'Add Property'}
+          </h2>
+          <button onClick={onClose} className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700"><X className="w-5 h-5" /></button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
+          {error && <div className="p-3 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-sm">{error}</div>}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="col-span-2">
+              <label className={labelClass}>Name *</label>
+              <input className={inputClass} value={form.name} onChange={e => update('name', e.target.value)} />
+            </div>
+            <div>
+              <label className={labelClass}>Property Type</label>
+              <select className={inputClass} value={form.property_type} onChange={e => update('property_type', e.target.value)}>
+                <option value="">— Select —</option>
+                {typeOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>Current Known Owner</label>
+              <select className={inputClass} value={form.owner_person_id} onChange={e => update('owner_person_id', e.target.value)}>
+                <option value="">— None —</option>
+                {people.map(p => <option key={p.id} value={p.id}>{`${p.first_name || ''} ${p.last_name || ''}`.trim()}</option>)}
+              </select>
+            </div>
+            <div className="col-span-2">
+              <label className={labelClass}>Address</label>
+              <input className={inputClass} value={form.address} onChange={e => update('address', e.target.value)} />
+            </div>
+            <div><label className={labelClass}>City</label><input className={inputClass} value={form.city} onChange={e => update('city', e.target.value)} /></div>
+            <div><label className={labelClass}>State</label><input className={inputClass} value={form.state} onChange={e => update('state', e.target.value)} /></div>
+            <div><label className={labelClass}>Country</label><input className={inputClass} value={form.country} onChange={e => update('country', e.target.value)} /></div>
+            <div><label className={labelClass}>Postal Code</label><input className={inputClass} value={form.postal_code} onChange={e => update('postal_code', e.target.value)} /></div>
+            <div><label className={labelClass}>Latitude (optional)</label><input className={inputClass} value={form.latitude} onChange={e => update('latitude', e.target.value)} placeholder="auto-geocoded if blank" /></div>
+            <div><label className={labelClass}>Longitude (optional)</label><input className={inputClass} value={form.longitude} onChange={e => update('longitude', e.target.value)} /></div>
+            <div className="col-span-2">
+              <label className={labelClass}>Case</label>
+              <select className={inputClass} value={form.case_id} onChange={e => update('case_id', e.target.value)}>
+                <option value="">— None —</option>
+                {cases.map(c => <option key={c.id} value={c.id}>{c.case_name}</option>)}
+              </select>
+            </div>
+            <div className="col-span-2">
+              <label className={labelClass}>Description</label>
+              <textarea className={inputClass} rows={2} value={form.description} onChange={e => update('description', e.target.value)} />
+            </div>
+            <div className="col-span-2">
+              <label className={labelClass}>Notes</label>
+              <textarea className={inputClass} rows={2} value={form.notes} onChange={e => update('notes', e.target.value)} />
+            </div>
+          </div>
+          <div className="flex justify-end space-x-3 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Cancel</button>
+            <button type="submit" disabled={saving} className="px-4 py-2 rounded-lg bg-blue-600 text-white disabled:opacity-60">{saving ? 'Saving…' : 'Save'}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddEditPropertyForm;

--- a/frontend/src/components/AddEditTransactionForm.js
+++ b/frontend/src/components/AddEditTransactionForm.js
@@ -1,0 +1,266 @@
+// File: frontend/src/components/AddEditTransactionForm.js
+import React, { useState, useEffect } from 'react';
+import { X, Receipt } from 'lucide-react';
+import { transactionsAPI, modelOptionsAPI, casesAPI } from '../utils/api';
+import { useData } from '../contexts/DataContext';
+
+const inputClass = 'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 dark:bg-gray-700 dark:text-white';
+const labelClass = 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1';
+
+const personLabel = (p) => `${p.first_name || ''} ${p.last_name || ''}`.trim();
+
+// Hoisted to module scope so the external-name input keeps focus across re-renders.
+const PartyPicker = ({ title, kind, setKind, id, setId, external, setExternal, people, businesses }) => {
+  const entities = kind === 'person' ? people : kind === 'business' ? businesses : [];
+  return (
+    <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-2">
+      <label className={labelClass}>{title}</label>
+      <select className={inputClass} value={kind} onChange={e => { setKind(e.target.value); setId(''); setExternal(''); }}>
+        <option value="none">— None —</option>
+        <option value="person">Person</option>
+        <option value="business">Business</option>
+        <option value="external">External (free text)</option>
+      </select>
+      {(kind === 'person' || kind === 'business') && (
+        <select className={inputClass} value={id} onChange={e => setId(e.target.value)}>
+          <option value="">— Select —</option>
+          {entities.map(ent => <option key={ent.id} value={ent.id}>{kind === 'person' ? personLabel(ent) : ent.name}</option>)}
+        </select>
+      )}
+      {kind === 'external' && <input className={inputClass} value={external} onChange={e => setExternal(e.target.value)} placeholder="External name" />}
+    </div>
+  );
+};
+
+const AddEditTransactionForm = ({ transaction, onClose }) => {
+  const { people, businesses, assets, properties, fetchTransactions } = useData();
+  const isEdit = !!transaction;
+  const [typeOptions, setTypeOptions] = useState([]);
+  const [itemCategoryOptions, setItemCategoryOptions] = useState([]);
+  const [cases, setCases] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const initialPartyKind = (t, dir) => {
+    if (!t) return 'none';
+    if (t[`${dir}_person_id`]) return 'person';
+    if (t[`${dir}_business_id`]) return 'business';
+    if (t[`${dir}_external`]) return 'external';
+    return 'none';
+  };
+  const initialSubjectKind = (t) => {
+    if (!t) return 'item';
+    if (t.subject_asset_id) return 'asset';
+    if (t.subject_business_id) return 'business';
+    if (t.subject_property_id) return 'property';
+    return 'item';
+  };
+  const initialLocationKind = (t) => {
+    if (!t) return 'none';
+    if (t.location_business_id) return 'business';
+    if (t.location_property_id) return 'property';
+    if (t.location_name || t.city || t.address) return 'place';
+    return 'none';
+  };
+
+  const [transaction_type, setType] = useState(transaction?.transaction_type || '');
+  const [fromKind, setFromKind] = useState(initialPartyKind(transaction, 'from'));
+  const [fromId, setFromId] = useState(transaction?.from_person_id || transaction?.from_business_id || '');
+  const [fromExternal, setFromExternal] = useState(transaction?.from_external || '');
+  const [toKind, setToKind] = useState(initialPartyKind(transaction, 'to'));
+  const [toId, setToId] = useState(transaction?.to_person_id || transaction?.to_business_id || '');
+  const [toExternal, setToExternal] = useState(transaction?.to_external || '');
+
+  const [subjectKind, setSubjectKind] = useState(initialSubjectKind(transaction));
+  const [itemLabel, setItemLabel] = useState(transaction?.item_label || '');
+  const [itemCategory, setItemCategory] = useState(transaction?.item_category || '');
+  const [subjectId, setSubjectId] = useState(transaction?.subject_asset_id || transaction?.subject_business_id || transaction?.subject_property_id || '');
+
+  const [value, setValue] = useState(transaction?.value || '');
+  const [currency, setCurrency] = useState(transaction?.currency || '');
+  const [occurredOn, setOccurredOn] = useState(transaction?.occurred_on ? String(transaction.occurred_on).slice(0, 10) : '');
+
+  const [locationKind, setLocationKind] = useState(initialLocationKind(transaction));
+  const [locationId, setLocationId] = useState(transaction?.location_business_id || transaction?.location_property_id || '');
+  const [place, setPlace] = useState({
+    location_name: transaction?.location_name || '', address: transaction?.address || '',
+    city: transaction?.city || '', state: transaction?.state || '', country: transaction?.country || '', postal_code: transaction?.postal_code || '',
+  });
+
+  const [caseId, setCaseId] = useState(transaction?.case_id || '');
+  const [notes, setNotes] = useState(transaction?.notes || '');
+
+  useEffect(() => {
+    modelOptionsAPI.getAll().then(d => {
+      setTypeOptions(d.filter(o => o.model_type === 'transaction_type' && o.is_active));
+      setItemCategoryOptions(d.filter(o => o.model_type === 'transaction_item_category' && o.is_active));
+    }).catch(() => {});
+    casesAPI.getAll().then(setCases).catch(() => {});
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!transaction_type) { setError('Transaction type is required'); return; }
+    if (fromKind === 'none' && toKind === 'none') { setError('At least one party (giver or receiver) is required'); return; }
+
+    const payload = {
+      transaction_type,
+      from_person_id: fromKind === 'person' ? fromId || null : null,
+      from_business_id: fromKind === 'business' ? fromId || null : null,
+      from_external: fromKind === 'external' ? fromExternal || null : null,
+      to_person_id: toKind === 'person' ? toId || null : null,
+      to_business_id: toKind === 'business' ? toId || null : null,
+      to_external: toKind === 'external' ? toExternal || null : null,
+      subject_asset_id: subjectKind === 'asset' ? subjectId || null : null,
+      subject_business_id: subjectKind === 'business' ? subjectId || null : null,
+      subject_property_id: subjectKind === 'property' ? subjectId || null : null,
+      item_label: subjectKind === 'item' ? itemLabel || null : null,
+      item_category: subjectKind === 'item' ? itemCategory || null : null,
+      value: value === '' ? null : parseFloat(value),
+      currency: currency || null,
+      occurred_on: occurredOn || null,
+      location_business_id: locationKind === 'business' ? locationId || null : null,
+      location_property_id: locationKind === 'property' ? locationId || null : null,
+      location_name: locationKind === 'place' ? place.location_name || null : null,
+      address: locationKind === 'place' ? place.address || null : null,
+      city: locationKind === 'place' ? place.city || null : null,
+      state: locationKind === 'place' ? place.state || null : null,
+      country: locationKind === 'place' ? place.country || null : null,
+      postal_code: locationKind === 'place' ? place.postal_code || null : null,
+      case_id: caseId || null,
+      notes: notes || null,
+    };
+    setSaving(true);
+    setError('');
+    try {
+      if (isEdit) await transactionsAPI.update(transaction.id, payload);
+      else await transactionsAPI.create(payload);
+      await fetchTransactions(0);
+      onClose();
+    } catch (err) {
+      setError(err.message || 'Failed to save transaction');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center"><Receipt className="w-5 h-5 mr-2 text-blue-600 dark:text-blue-400" />{isEdit ? 'Edit Transaction' : 'Add Transaction'}</h2>
+          <button onClick={onClose} className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700"><X className="w-5 h-5" /></button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
+          {error && <div className="p-3 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-sm">{error}</div>}
+
+          <div className="grid grid-cols-2 gap-4">
+            <div><label className={labelClass}>Type *</label>
+              <select className={inputClass} value={transaction_type} onChange={e => setType(e.target.value)}>
+                <option value="">— Select —</option>
+                {typeOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+              </select>
+            </div>
+            <div><label className={labelClass}>Date</label><input type="date" className={inputClass} value={occurredOn} onChange={e => setOccurredOn(e.target.value)} /></div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <PartyPicker title="From (giver)" kind={fromKind} setKind={setFromKind} id={fromId} setId={setFromId} external={fromExternal} setExternal={setFromExternal} people={people} businesses={businesses} />
+            <PartyPicker title="To (receiver)" kind={toKind} setKind={setToKind} id={toId} setId={setToId} external={toExternal} setExternal={setToExternal} people={people} businesses={businesses} />
+          </div>
+
+          {/* Subject picker */}
+          <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-2">
+            <label className={labelClass}>Subject (what changed hands)</label>
+            <select className={inputClass} value={subjectKind} onChange={e => { setSubjectKind(e.target.value); setSubjectId(''); }}>
+              <option value="item">Free-text item</option>
+              <option value="asset">Asset</option>
+              <option value="business">Business</option>
+              <option value="property">Property</option>
+            </select>
+            {subjectKind === 'item' && (
+              <div className="grid grid-cols-2 gap-3">
+                <input className={inputClass} value={itemLabel} onChange={e => setItemLabel(e.target.value)} placeholder="e.g. Baseball tickets" />
+                <select className={inputClass} value={itemCategory} onChange={e => setItemCategory(e.target.value)}>
+                  <option value="">— Category —</option>
+                  {itemCategoryOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+                </select>
+              </div>
+            )}
+            {subjectKind === 'asset' && (
+              <select className={inputClass} value={subjectId} onChange={e => setSubjectId(e.target.value)}>
+                <option value="">— Select asset —</option>
+                {assets.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+              </select>
+            )}
+            {subjectKind === 'business' && (
+              <select className={inputClass} value={subjectId} onChange={e => setSubjectId(e.target.value)}>
+                <option value="">— Select business —</option>
+                {businesses.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+              </select>
+            )}
+            {subjectKind === 'property' && (
+              <select className={inputClass} value={subjectId} onChange={e => setSubjectId(e.target.value)}>
+                <option value="">— Select property —</option>
+                {properties.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div><label className={labelClass}>Value</label><input className={inputClass} value={value} onChange={e => setValue(e.target.value)} placeholder="0.00" /></div>
+            <div><label className={labelClass}>Currency</label><input className={inputClass} value={currency} onChange={e => setCurrency(e.target.value)} placeholder="USD" /></div>
+          </div>
+
+          {/* Location picker */}
+          <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-2">
+            <label className={labelClass}>Where it happened</label>
+            <select className={inputClass} value={locationKind} onChange={e => { setLocationKind(e.target.value); setLocationId(''); }}>
+              <option value="none">— None —</option>
+              <option value="business">Business venue</option>
+              <option value="property">Property</option>
+              <option value="place">Free-text place (geocoded)</option>
+            </select>
+            {locationKind === 'business' && (
+              <select className={inputClass} value={locationId} onChange={e => setLocationId(e.target.value)}>
+                <option value="">— Select business —</option>
+                {businesses.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+              </select>
+            )}
+            {locationKind === 'property' && (
+              <select className={inputClass} value={locationId} onChange={e => setLocationId(e.target.value)}>
+                <option value="">— Select property —</option>
+                {properties.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            )}
+            {locationKind === 'place' && (
+              <div className="grid grid-cols-2 gap-3">
+                <input className={inputClass} value={place.location_name} onChange={e => setPlace({ ...place, location_name: e.target.value })} placeholder="Place name" />
+                <input className={inputClass} value={place.address} onChange={e => setPlace({ ...place, address: e.target.value })} placeholder="Address" />
+                <input className={inputClass} value={place.city} onChange={e => setPlace({ ...place, city: e.target.value })} placeholder="City" />
+                <input className={inputClass} value={place.country} onChange={e => setPlace({ ...place, country: e.target.value })} placeholder="Country" />
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div><label className={labelClass}>Case</label>
+              <select className={inputClass} value={caseId} onChange={e => setCaseId(e.target.value)}>
+                <option value="">— None —</option>
+                {cases.map(c => <option key={c.id} value={c.id}>{c.case_name}</option>)}
+              </select>
+            </div>
+            <div className="col-span-2"><label className={labelClass}>Notes</label><textarea className={inputClass} rows={2} value={notes} onChange={e => setNotes(e.target.value)} /></div>
+          </div>
+
+          <div className="flex justify-end space-x-3 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Cancel</button>
+            <button type="submit" disabled={saving} className="px-4 py-2 rounded-lg bg-blue-600 text-white disabled:opacity-60">{saving ? 'Saving…' : 'Save'}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddEditTransactionForm;

--- a/frontend/src/components/AssetDetailModal.js
+++ b/frontend/src/components/AssetDetailModal.js
@@ -1,0 +1,69 @@
+// File: frontend/src/components/AssetDetailModal.js
+import React, { useState, useEffect } from 'react';
+import { Package, X, Edit2, MapPin, User, Hash } from 'lucide-react';
+import { assetsAPI } from '../utils/api';
+import { useUI } from '../contexts/UIContext';
+import ChainOfCustodyTimeline from './ChainOfCustodyTimeline';
+import { formatMoney, formatDate, prettyType } from '../utils/transactionFormat';
+
+const AssetDetailModal = ({ asset: initial, onClose }) => {
+  const { setEditingAsset } = useUI();
+  const [asset, setAsset] = useState(initial);
+  const [tab, setTab] = useState('details');
+
+  useEffect(() => {
+    assetsAPI.getById(initial.id).then(setAsset).catch(err => console.error('Error loading asset:', err));
+  }, [initial.id]);
+
+  const loc = asset.resolved_location;
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <div className="flex items-center space-x-3">
+            <div className="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center"><Package className="w-6 h-6 text-orange-600 dark:text-orange-400" /></div>
+            <div>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">{asset.name}</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 capitalize">{[asset.category, asset.status].filter(Boolean).join(' · ').replace(/_/g, ' ')}</p>
+            </div>
+          </div>
+          <div className="flex space-x-2">
+            <button onClick={() => { onClose(); setEditingAsset(asset); }} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white"><Edit2 className="w-5 h-5" /></button>
+            <button onClick={onClose} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-red-600 hover:text-white"><X className="w-5 h-5" /></button>
+          </div>
+        </div>
+
+        <div className="border-b border-gray-200 dark:border-gray-700 flex">
+          {['details', 'custody'].map(t => (
+            <button key={t} onClick={() => setTab(t)} className={`px-5 py-3 text-sm font-medium capitalize border-b-2 ${tab === t ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`}>{t === 'custody' ? 'Chain of Custody' : t}</button>
+          ))}
+        </div>
+
+        <div className="overflow-y-auto p-5" style={{ maxHeight: 'calc(90vh - 170px)' }}>
+          {tab === 'details' && (
+            <div className="space-y-4 text-sm">
+              <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-300 flex items-center">
+                <User className="w-4 h-4 mr-2" />Current holder: <strong className="ml-1">{asset.current_holder ? asset.current_holder.label : 'None'}</strong>
+                {asset.holder_since ? <span className="ml-1">(since {formatDate(asset.holder_since)})</span> : null}
+              </div>
+              {asset.identifier && <div className="flex items-center text-gray-700 dark:text-gray-300"><Hash className="w-4 h-4 mr-2 text-gray-400" />{asset.identifier}</div>}
+              {asset.estimated_value != null && <div className="text-gray-700 dark:text-gray-300">Estimated value: {formatMoney(asset.estimated_value, asset.currency)}</div>}
+              <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700">
+                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 flex items-center"><MapPin className="w-3 h-3 mr-1" />Resolved location ({prettyType(asset.location_mode)})</div>
+                {loc && loc.latitude != null ? (
+                  <div className="text-gray-800 dark:text-gray-200">{loc.label || 'Located'} · {Number(loc.latitude).toFixed(4)}, {Number(loc.longitude).toFixed(4)} <span className="text-xs text-gray-500">({loc.source})</span></div>
+                ) : <div className="text-gray-500 dark:text-gray-400">Location unknown</div>}
+              </div>
+              {asset.description && <div><h4 className="font-semibold text-gray-900 dark:text-white mb-1">Description</h4><p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{asset.description}</p></div>}
+              {asset.notes && <div><h4 className="font-semibold text-gray-900 dark:text-white mb-1">Notes</h4><p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{asset.notes}</p></div>}
+            </div>
+          )}
+          {tab === 'custody' && <ChainOfCustodyTimeline chain={asset.chain_of_custody || []} emptyText="No custody movements recorded." />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AssetDetailModal;

--- a/frontend/src/components/AssetsList.js
+++ b/frontend/src/components/AssetsList.js
@@ -1,0 +1,139 @@
+// File: frontend/src/components/AssetsList.js
+import React, { useState, useEffect, useCallback, memo } from 'react';
+import { FixedSizeList } from 'react-window';
+import { Package, Search, Plus, Edit2, Trash2, Eye, MapPin, User, Hash } from 'lucide-react';
+import { assetsAPI, modelOptionsAPI } from '../utils/api';
+import { useData } from '../contexts/DataContext';
+import { useUI } from '../contexts/UIContext';
+
+const VIRTUAL_THRESHOLD = 150;
+const ITEM_HEIGHT = 160;
+
+const AssetsList = () => {
+  const { assets, fetchAssets, assetsMeta, loadMoreAssets } = useData();
+  const { setShowAddAssetForm, setEditingAsset, setSelectedAssetForDetail } = useUI();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterCategory, setFilterCategory] = useState('');
+  const [filterStatus, setFilterStatus] = useState('');
+  const [categoryOptions, setCategoryOptions] = useState([]);
+  const [statusOptions, setStatusOptions] = useState([]);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    modelOptionsAPI.getAll().then(d => {
+      setCategoryOptions(d.filter(o => o.model_type === 'asset_category' && o.is_active));
+      setStatusOptions(d.filter(o => o.model_type === 'asset_status' && o.is_active));
+    }).catch(err => console.error('Error loading asset options:', err));
+  }, []);
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this asset?')) return;
+    try { await assetsAPI.remove(id); fetchAssets(0); }
+    catch (err) { alert('Failed to delete asset: ' + err.message); }
+  };
+
+  const filtered = assets.filter(a => {
+    const matchesSearch = searchTerm === '' ||
+      (a.name && a.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
+      (a.identifier && a.identifier.toLowerCase().includes(searchTerm.toLowerCase()));
+    const matchesCategory = filterCategory === '' || a.category === filterCategory;
+    const matchesStatus = filterStatus === '' || a.status === filterStatus;
+    return matchesSearch && matchesCategory && matchesStatus;
+  });
+
+  const Card = ({ asset }) => (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg p-5 hover:shadow-md transition-shadow group">
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex items-center space-x-3 min-w-0">
+          <div className="w-11 h-11 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+            <Package className="w-6 h-6 text-orange-600 dark:text-orange-400" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">{asset.name}</h3>
+            <div className="flex items-center gap-2 flex-wrap">
+              {asset.category && <span className="text-xs px-2 py-0.5 rounded bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300 capitalize">{asset.category.replace(/_/g, ' ')}</span>}
+              {asset.status && <span className="text-xs px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 capitalize">{asset.status}</span>}
+            </div>
+          </div>
+        </div>
+        <div className="flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button onClick={() => setSelectedAssetForDetail(asset)} className="p-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white" title="View"><Eye className="w-4 h-4" /></button>
+          <button onClick={() => setEditingAsset(asset)} className="p-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-600 hover:text-white" title="Edit"><Edit2 className="w-4 h-4" /></button>
+          <button onClick={() => handleDelete(asset.id)} className="p-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-red-600 dark:text-red-400 hover:bg-red-600 hover:text-white" title="Delete"><Trash2 className="w-4 h-4" /></button>
+        </div>
+      </div>
+      <div className="space-y-1.5 text-sm">
+        {asset.identifier && <div className="flex items-center text-gray-700 dark:text-gray-300"><Hash className="w-4 h-4 mr-2 text-gray-400" /><span className="truncate">{asset.identifier}</span></div>}
+        <div className="flex items-center text-gray-700 dark:text-gray-300"><User className="w-4 h-4 mr-2 text-gray-400" />Holder: {asset.current_holder ? asset.current_holder.label : '—'}</div>
+        {asset.resolved_location && asset.resolved_location.latitude != null && (
+          <div className="flex items-center text-gray-700 dark:text-gray-300"><MapPin className="w-4 h-4 mr-2 text-gray-400" /><span className="truncate">{asset.resolved_location.label || 'Located'} ({asset.location_mode?.replace(/_/g, ' ')})</span></div>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderVirtual = useCallback(({ index, style }) => (
+    <div style={{ ...style, paddingBottom: 16 }}><Card asset={filtered[index]} /></div>
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [filtered]);
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Assets</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-2 flex items-center">
+            <Package className="w-5 h-5 mr-2 text-orange-600 dark:text-orange-400" />
+            <span className="font-medium">{assets.length}{assetsMeta.total > assets.length ? ` of ${assetsMeta.total}` : ''} assets</span>
+          </p>
+        </div>
+        <button onClick={() => setShowAddAssetForm(true)} className="px-6 py-3 bg-blue-600 text-white dark:bg-blue-500 rounded-lg hover:shadow-glow-md transition flex items-center active:scale-[0.97]">
+          <Plus className="w-5 h-5 mr-2" />Add Asset
+        </button>
+      </div>
+
+      <div className="mb-6 flex space-x-4">
+        <div className="flex-1 max-w-md relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-blue-600 dark:text-blue-400 w-5 h-5" />
+          <input type="text" placeholder="Search by name or identifier…" value={searchTerm} onChange={e => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500" />
+        </div>
+        <select value={filterCategory} onChange={e => setFilterCategory(e.target.value)} className="px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-800 dark:text-white">
+          <option value="">All Categories</option>
+          {categoryOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+        </select>
+        <select value={filterStatus} onChange={e => setFilterStatus(e.target.value)} className="px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-800 dark:text-white">
+          <option value="">All Statuses</option>
+          {statusOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <Package className="w-12 h-12 text-gray-400 mx-auto mb-3" />
+          <p className="text-gray-600 dark:text-gray-400">No assets found.</p>
+        </div>
+      ) : filtered.length >= VIRTUAL_THRESHOLD ? (
+        <FixedSizeList height={Math.min(filtered.length * ITEM_HEIGHT, 700)} itemCount={filtered.length} itemSize={ITEM_HEIGHT} width="100%" overscanCount={3}>
+          {renderVirtual}
+        </FixedSizeList>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map(a => <Card key={a.id} asset={a} />)}
+        </div>
+      )}
+
+      {assetsMeta.hasMore && filtered.length === assets.length && (
+        <div className="flex flex-col items-center py-6 space-y-2">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Showing {assets.length} of {assetsMeta.total}</p>
+          <button onClick={async () => { setLoadingMore(true); await loadMoreAssets(); setLoadingMore(false); }} disabled={loadingMore}
+            className="px-5 py-2.5 bg-blue-600 dark:bg-blue-500 text-white rounded-lg text-sm font-medium disabled:opacity-60">
+            {loadingMore ? 'Loading…' : `Load more (${assetsMeta.total - assets.length} remaining)`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default memo(AssetsList);

--- a/frontend/src/components/BusinessDetailModal.js
+++ b/frontend/src/components/BusinessDetailModal.js
@@ -1,0 +1,99 @@
+// File: frontend/src/components/BusinessDetailModal.js
+import React, { useState, useEffect } from 'react';
+import { Building2, X, Edit2, Users, Calendar, FileText, MapPin } from 'lucide-react';
+import { transactionsAPI, ledgerAPI } from '../utils/api';
+import { useUI } from '../contexts/UIContext';
+import TransactionTable from './TransactionTable';
+import EntityLedger from './EntityLedger';
+import ReportGenerator from './ReportGenerator';
+import { formatDate, prettyType } from '../utils/transactionFormat';
+
+const BusinessDetailModal = ({ business, onClose }) => {
+  const { setEditingBusiness, setSelectedPersonForDetail } = useUI();
+  const [tab, setTab] = useState('venue');
+  const [txns, setTxns] = useState([]);
+  const [venue, setVenue] = useState(null);
+  const [showReport, setShowReport] = useState(false);
+
+  useEffect(() => {
+    transactionsAPI.getByBusiness(business.id).then(r => setTxns(r.data || [])).catch(err => console.error(err));
+    ledgerAPI.venueStats(business.id).then(setVenue).catch(err => console.error(err));
+  }, [business.id]);
+
+  const tabs = ['venue', 'transactions', 'ledger'];
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+          <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+            <div className="flex items-center space-x-3">
+              <div className="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center"><Building2 className="w-6 h-6 text-indigo-600 dark:text-indigo-400" /></div>
+              <div>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">{business.name}</h2>
+                {business.industry && <p className="text-sm text-gray-500 dark:text-gray-400">{business.industry}</p>}
+              </div>
+            </div>
+            <div className="flex space-x-2">
+              <button onClick={() => setShowReport(true)} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-green-600 dark:text-green-400 hover:bg-green-600 hover:text-white" title="Ledger report"><FileText className="w-5 h-5" /></button>
+              <button onClick={() => { onClose(); setEditingBusiness(business); }} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white"><Edit2 className="w-5 h-5" /></button>
+              <button onClick={onClose} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-red-600 hover:text-white"><X className="w-5 h-5" /></button>
+            </div>
+          </div>
+
+          <div className="border-b border-gray-200 dark:border-gray-700 flex">
+            {tabs.map(t => (
+              <button key={t} onClick={() => setTab(t)} className={`px-5 py-3 text-sm font-medium capitalize border-b-2 ${tab === t ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`}>{t === 'venue' ? 'Venue Activity' : t}</button>
+            ))}
+          </div>
+
+          <div className="overflow-y-auto p-5" style={{ maxHeight: 'calc(90vh - 170px)' }}>
+            {tab === 'venue' && (
+              venue ? (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                    <div className="p-3 rounded-lg bg-cyan-50 dark:bg-cyan-900/20 border border-cyan-200 dark:border-cyan-800">
+                      <div className="text-xs text-cyan-700 dark:text-cyan-400 flex items-center"><Users className="w-3 h-3 mr-1" />Distinct people</div>
+                      <div className="text-2xl font-bold text-cyan-700 dark:text-cyan-300">{venue.distinct_people}</div>
+                    </div>
+                    <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+                      <div className="text-xs text-gray-500 dark:text-gray-400">Events</div>
+                      <div className="text-2xl font-bold text-gray-900 dark:text-white">{venue.event_count}</div>
+                    </div>
+                    <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+                      <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center"><Calendar className="w-3 h-3 mr-1" />First</div>
+                      <div className="text-sm font-bold text-gray-900 dark:text-white">{formatDate(venue.first_event)}</div>
+                    </div>
+                    <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+                      <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center"><Calendar className="w-3 h-3 mr-1" />Last</div>
+                      <div className="text-sm font-bold text-gray-900 dark:text-white">{formatDate(venue.last_event)}</div>
+                    </div>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center"><MapPin className="w-4 h-4 mr-1 text-gray-400" />Associated people (ranked)</h4>
+                    {venue.people && venue.people.length ? (
+                      <div className="space-y-2">
+                        {venue.people.map(p => (
+                          <button key={p.id} onClick={() => { onClose(); setSelectedPersonForDetail({ id: p.id }); }}
+                            className="w-full flex justify-between items-center p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 text-left">
+                            <span className="text-gray-800 dark:text-gray-200">{p.label}</span>
+                            <span className="text-xs text-gray-500 dark:text-gray-400">{p.event_count} event{p.event_count !== 1 ? 's' : ''}</span>
+                          </button>
+                        ))}
+                      </div>
+                    ) : <p className="text-sm text-gray-500 dark:text-gray-400">No venue activity recorded.</p>}
+                  </div>
+                </div>
+              ) : <p className="text-sm text-gray-500 dark:text-gray-400 py-6 text-center">Loading venue activity…</p>
+            )}
+            {tab === 'transactions' && <TransactionTable transactions={txns} showRole emptyText="No transactions involving this business." />}
+            {tab === 'ledger' && <EntityLedger entityType="businesses" entityId={business.id} />}
+          </div>
+        </div>
+      </div>
+      {showReport && <ReportGenerator ledgerEntity={{ type: 'businesses', id: business.id, label: business.name }} onClose={() => setShowReport(false)} />}
+    </>
+  );
+};
+
+export default BusinessDetailModal;

--- a/frontend/src/components/BusinessList.js
+++ b/frontend/src/components/BusinessList.js
@@ -1,13 +1,13 @@
 // File: frontend/src/components/BusinessList.js
 import React, { useState } from 'react';
-import { Building2, Search, Plus, Edit2, Trash2, Users, MapPin, Phone, Mail, Globe, User } from 'lucide-react';
+import { Building2, Search, Plus, Edit2, Trash2, Users, MapPin, Phone, Mail, Globe, User, Eye } from 'lucide-react';
 import { businessAPI } from '../utils/api';
 import { useData } from '../contexts/DataContext';
 import { useUI } from '../contexts/UIContext';
 
 const BusinessList = () => {
   const { businesses, fetchBusinesses } = useData();
-  const { setShowAddBusinessForm, setEditingBusiness } = useUI();
+  const { setShowAddBusinessForm, setEditingBusiness, setSelectedBusinessForDetail } = useUI();
   const [searchTerm, setSearchTerm] = useState('');
   const [filterIndustry, setFilterIndustry] = useState('');
   const [filterStatus, setFilterStatus] = useState('');
@@ -126,6 +126,13 @@ const BusinessList = () => {
                 </div>
               </div>
               <div className="flex space-x-1">
+                <button
+                  onClick={() => setSelectedBusinessForDetail(business)}
+                  className="text-blue-600 dark:text-blue-400 hover:text-blue-700"
+                  title="View details"
+                >
+                  <Eye className="w-4 h-4" />
+                </button>
                 <button
                   onClick={() => setEditingBusiness(business)}
                   className="text-gray-600 dark:text-slate-400 hover:text-gray-700"

--- a/frontend/src/components/ChainOfCustodyTimeline.js
+++ b/frontend/src/components/ChainOfCustodyTimeline.js
@@ -1,0 +1,33 @@
+// File: frontend/src/components/ChainOfCustodyTimeline.js
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { formatDate, formatMoney, partyText, prettyType, typeBadgeClass } from '../utils/transactionFormat';
+
+// Renders an ordered chain-of-custody / ownership timeline.
+// `chain` items: { transaction_id, occurred_on, transaction_type, from, to, value, currency }
+const ChainOfCustodyTimeline = ({ chain = [], emptyText = 'No custody history yet.' }) => {
+  if (!chain.length) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">{emptyText}</p>;
+  }
+  return (
+    <ol className="relative border-l border-gray-200 dark:border-gray-700 ml-3">
+      {chain.map((c, i) => (
+        <li key={`${c.transaction_id}-${i}`} className="mb-5 ml-5">
+          <span className="absolute -left-1.5 w-3 h-3 rounded-full bg-blue-500 border border-white dark:border-gray-800" />
+          <div className="flex items-center flex-wrap gap-2">
+            <span className={`text-xs px-2 py-0.5 rounded font-medium capitalize ${typeBadgeClass(c.transaction_type)}`}>{prettyType(c.transaction_type)}</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">{formatDate(c.occurred_on)}</span>
+            {c.value != null && <span className="text-xs text-gray-700 dark:text-gray-300">· {formatMoney(c.value, c.currency)}</span>}
+          </div>
+          <div className="flex items-center text-sm text-gray-800 dark:text-gray-200 mt-1">
+            <span>{partyText(c.from)}</span>
+            <ArrowRight className="w-4 h-4 mx-2 text-gray-400" />
+            <span className="font-medium">{partyText(c.to)}</span>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+export default ChainOfCustodyTimeline;

--- a/frontend/src/components/EntityLedger.js
+++ b/frontend/src/components/EntityLedger.js
@@ -1,0 +1,134 @@
+// File: frontend/src/components/EntityLedger.js
+import React, { useState, useEffect, useCallback } from 'react';
+import { ArrowDownLeft, ArrowUpRight, Minus, Package } from 'lucide-react';
+import { ledgerAPI } from '../utils/api';
+import { formatDate, formatMoney, partyText, subjectText, prettyType, typeBadgeClass, directionClass } from '../utils/transactionFormat';
+
+// entityType: 'people' | 'businesses' | 'properties'
+const EntityLedger = ({ entityType, entityId }) => {
+  const [ledger, setLedger] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await ledgerAPI.get(entityType, entityId, { date_from: dateFrom, date_to: dateTo });
+      setLedger(data);
+    } catch (err) {
+      setError(err.message || 'Failed to load ledger');
+    } finally {
+      setLoading(false);
+    }
+  }, [entityType, entityId, dateFrom, dateTo]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading ledger…</div>;
+  if (error) return <div className="py-8 text-center text-red-600 dark:text-red-400">{error}</div>;
+  if (!ledger) return null;
+
+  const { summary, entries } = ledger;
+
+  return (
+    <div className="space-y-5">
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">From</label>
+          <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white" />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">To</label>
+          <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white" />
+        </div>
+        {(dateFrom || dateTo) && (
+          <button onClick={() => { setDateFrom(''); setDateTo(''); }} className="px-3 py-1.5 text-sm rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Clear</button>
+        )}
+      </div>
+
+      {/* Summary */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div className="p-3 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
+          <div className="text-xs text-green-700 dark:text-green-400 flex items-center"><ArrowDownLeft className="w-3 h-3 mr-1" />Value In</div>
+          <div className="text-lg font-bold text-green-700 dark:text-green-300">{summary.value_in != null ? formatMoney(summary.value_in) : '—'}</div>
+        </div>
+        <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+          <div className="text-xs text-red-700 dark:text-red-400 flex items-center"><ArrowUpRight className="w-3 h-3 mr-1" />Value Out</div>
+          <div className="text-lg font-bold text-red-700 dark:text-red-300">{summary.value_out != null ? formatMoney(summary.value_out) : '—'}</div>
+        </div>
+        <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+          <div className="text-xs text-gray-500 dark:text-gray-400">Net</div>
+          <div className="text-lg font-bold text-gray-900 dark:text-white">{summary.net != null ? formatMoney(summary.net) : 'mixed'}</div>
+        </div>
+        <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+          <div className="text-xs text-gray-500 dark:text-gray-400">Counterparties</div>
+          <div className="text-lg font-bold text-gray-900 dark:text-white">{summary.distinct_counterparties}</div>
+        </div>
+      </div>
+
+      {summary.by_currency && summary.by_currency.length > 1 && (
+        <div className="text-xs text-gray-600 dark:text-gray-400">
+          Per currency: {summary.by_currency.map(c => `${c.currency || 'unspec'}: in ${formatMoney(c.value_in)} / out ${formatMoney(c.value_out)}`).join(' · ')}
+        </div>
+      )}
+
+      {summary.assets_currently_held && summary.assets_currently_held.length > 0 && (
+        <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 flex items-center"><Package className="w-3 h-3 mr-1" />Currently Held Assets</div>
+          <div className="flex flex-wrap gap-2">
+            {summary.assets_currently_held.map(a => (
+              <span key={a.id} className="text-xs px-2 py-1 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 text-gray-800 dark:text-gray-200">
+                {a.name}{a.since ? ` · since ${formatDate(a.since)}` : ''}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Ledger table */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+              <th className="py-2 pr-3 font-medium">Date</th>
+              <th className="py-2 pr-3 font-medium">Type</th>
+              <th className="py-2 pr-3 font-medium">Role</th>
+              <th className="py-2 pr-3 font-medium">Counterparty</th>
+              <th className="py-2 pr-3 font-medium">Subject</th>
+              <th className="py-2 pr-3 font-medium text-right">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 ? (
+              <tr><td colSpan={6} className="py-6 text-center text-gray-500 dark:text-gray-400">No ledger entries.</td></tr>
+            ) : entries.map((e, i) => (
+              <tr key={`${e.transaction_id}-${e.role}-${i}`} className="border-b border-gray-100 dark:border-gray-700/50">
+                <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">{formatDate(e.occurred_on)}</td>
+                <td className="py-2 pr-3"><span className={`text-xs px-2 py-0.5 rounded capitalize ${typeBadgeClass(e.transaction_type)}`}>{prettyType(e.transaction_type)}</span></td>
+                <td className="py-2 pr-3 text-gray-600 dark:text-gray-400 capitalize">{prettyType(e.role)}</td>
+                <td className="py-2 pr-3 text-gray-800 dark:text-gray-200">{partyText(e.counterparty)}</td>
+                <td className="py-2 pr-3 text-gray-700 dark:text-gray-300">{subjectText(e.subject)}</td>
+                <td className={`py-2 pr-3 text-right whitespace-nowrap font-medium ${directionClass(e.value_direction)}`}>
+                  {e.value != null ? (
+                    <span className="inline-flex items-center justify-end">
+                      {e.value_direction === 'in' && <ArrowDownLeft className="w-3 h-3 mr-1" />}
+                      {e.value_direction === 'out' && <ArrowUpRight className="w-3 h-3 mr-1" />}
+                      {e.value_direction === 'neutral' && <Minus className="w-3 h-3 mr-1" />}
+                      {formatMoney(e.value, e.currency)}
+                    </span>
+                  ) : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default EntityLedger;

--- a/frontend/src/components/GlobalMap.js
+++ b/frontend/src/components/GlobalMap.js
@@ -4,8 +4,8 @@ import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-cluster';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import { Search, RefreshCw, Plus, AlertCircle, Wifi, Filter } from 'lucide-react';
-import { wirelessNetworksAPI } from '../utils/api';
+import { Search, RefreshCw, Plus, AlertCircle, Wifi, Filter, Landmark, Package, Receipt } from 'lucide-react';
+import { wirelessNetworksAPI, propertiesAPI, assetsAPI, transactionsAPI, modelOptionsAPI } from '../utils/api';
 import { OSM_TILE_URL, OSM_ATTRIBUTION } from '../utils/mapConstants';
 import { locationColors, buildIconCache } from './map/mapUtils';
 import AddLocationModal from './map/AddLocationModal';
@@ -35,6 +35,17 @@ const GlobalMap = () => {
   const [filteredPeople, setFilteredPeople] = useState([]);
   const [wirelessNetworks, setWirelessNetworks] = useState([]);
   const [showNetworks, setShowNetworks] = useState(true);
+  // Transaction-tracking layers (issue #43)
+  const [properties, setProperties] = useState([]);
+  const [assets, setAssets] = useState([]);
+  const [txEvents, setTxEvents] = useState([]);
+  const [showProperties, setShowProperties] = useState(true);
+  const [showAssets, setShowAssets] = useState(true);
+  const [showTransactions, setShowTransactions] = useState(false);
+  const [filterTxType, setFilterTxType] = useState('');
+  const [filterAssetCategory, setFilterAssetCategory] = useState('');
+  const [txTypeOptions, setTxTypeOptions] = useState([]);
+  const [assetCategoryOptions, setAssetCategoryOptions] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [includeRelated, setIncludeRelated] = useState(false);
   const [selectedLocationTypes, setSelectedLocationTypes] = useState(Object.keys(locationColors));
@@ -53,7 +64,26 @@ const GlobalMap = () => {
     fetchAllPeople();
     fetchWirelessNetworks();
     fetchGeocodingStats();
+    fetchTransactionLayers();
   }, []);
+
+  const fetchTransactionLayers = async () => {
+    try {
+      const [props, asts, txns] = await Promise.all([
+        propertiesAPI.getAll({ limit: 1000 }),
+        assetsAPI.getAll({ limit: 1000 }),
+        transactionsAPI.getAll({ limit: 1000 }),
+      ]);
+      setProperties((props.data || []).filter(p => p.latitude && p.longitude));
+      setAssets((asts.data || []).filter(a => a.resolved_location && a.resolved_location.latitude != null));
+      setTxEvents((txns.data || []).filter(t => t.latitude && t.longitude));
+      const opts = await modelOptionsAPI.getAll();
+      setTxTypeOptions(opts.filter(o => o.model_type === 'transaction_type' && o.is_active));
+      setAssetCategoryOptions(opts.filter(o => o.model_type === 'asset_category' && o.is_active));
+    } catch (err) {
+      console.error('Error fetching transaction map layers:', err);
+    }
+  };
 
   const fetchPeople = async (page = 0, limit = 100) => {
     try {
@@ -173,6 +203,16 @@ const GlobalMap = () => {
 
   const iconCache = useMemo(() => buildIconCache(), []);
 
+  // Simple coloured pin icons for the transaction-tracking layers.
+  const featureIcons = useMemo(() => {
+    const make = (color, glyph) => L.divIcon({
+      className: 'ghost-feature-icon',
+      html: `<div style="background:${color};width:22px;height:22px;border-radius:50% 50% 50% 0;transform:rotate(-45deg);border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;"><span style="transform:rotate(45deg);font-size:11px;color:#fff;font-weight:bold;">${glyph}</span></div>`,
+      iconSize: [22, 22], iconAnchor: [11, 22], popupAnchor: [0, -20],
+    });
+    return { property: make('#059669', 'P'), asset: make('#ea580c', 'A'), transaction: make('#2563eb', 'T') };
+  }, []);
+
   const markers = useMemo(() => {
     const list = [];
     filteredPeople.forEach(person => {
@@ -215,8 +255,42 @@ const GlobalMap = () => {
         });
       });
     }
+    if (showProperties) {
+      properties.forEach(p => {
+        list.push({
+          id: `property-${p.id}`, kind: 'property', lat: parseFloat(p.latitude), lng: parseFloat(p.longitude),
+          name: p.name, propertyType: p.property_type, address: [p.address, p.city, p.country].filter(Boolean).join(', '),
+          ownerName: p.owner_name, icon: featureIcons.property,
+        });
+      });
+    }
+    if (showAssets) {
+      assets.forEach(a => {
+        if (filterAssetCategory && a.category !== filterAssetCategory) return;
+        const loc = a.resolved_location;
+        list.push({
+          id: `asset-${a.id}`, kind: 'asset', lat: parseFloat(loc.latitude), lng: parseFloat(loc.longitude),
+          name: a.name, assetCategory: a.category, locationMode: a.location_mode,
+          holderName: a.current_holder ? a.current_holder.label : null,
+          locLabel: loc.label, icon: featureIcons.asset,
+        });
+      });
+    }
+    if (showTransactions) {
+      txEvents.forEach(t => {
+        if (filterTxType && t.transaction_type !== filterTxType) return;
+        list.push({
+          id: `tx-${t.id}`, kind: 'transaction', lat: parseFloat(t.latitude), lng: parseFloat(t.longitude),
+          txType: t.transaction_type, fromLabel: t.resolved_from && t.resolved_from.label, toLabel: t.resolved_to && t.resolved_to.label,
+          subjectLabel: t.resolved_subject && t.resolved_subject.label, value: t.value, currency: t.currency,
+          locLabel: t.location_name || t.resolved_location?.label, icon: featureIcons.transaction,
+        });
+      });
+    }
     return list;
-  }, [filteredPeople, selectedLocationTypes, iconCache, wirelessNetworks, showNetworks]);
+  }, [filteredPeople, selectedLocationTypes, iconCache, wirelessNetworks, showNetworks,
+      properties, assets, txEvents, showProperties, showAssets, showTransactions,
+      filterAssetCategory, filterTxType, featureIcons]);
 
   const toggleLocationType = (type) =>
     setSelectedLocationTypes(prev => prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]);
@@ -293,6 +367,18 @@ const GlobalMap = () => {
                 Wireless Networks ({wirelessNetworks.length})
               </span>
             </label>
+            <label className="flex items-center space-x-2 cursor-pointer">
+              <input type="checkbox" checked={showProperties} onChange={e => setShowProperties(e.target.checked)} className="h-4 w-4 text-emerald-600 rounded" />
+              <span className="text-sm text-gray-700 dark:text-gray-300 flex items-center"><Landmark className="w-4 h-4 mr-1" />Properties ({properties.length})</span>
+            </label>
+            <label className="flex items-center space-x-2 cursor-pointer">
+              <input type="checkbox" checked={showAssets} onChange={e => setShowAssets(e.target.checked)} className="h-4 w-4 text-orange-600 rounded" />
+              <span className="text-sm text-gray-700 dark:text-gray-300 flex items-center"><Package className="w-4 h-4 mr-1" />Assets ({assets.length})</span>
+            </label>
+            <label className="flex items-center space-x-2 cursor-pointer">
+              <input type="checkbox" checked={showTransactions} onChange={e => setShowTransactions(e.target.checked)} className="h-4 w-4 text-blue-600 rounded" />
+              <span className="text-sm text-gray-700 dark:text-gray-300 flex items-center"><Receipt className="w-4 h-4 mr-1" />Transactions ({txEvents.length})</span>
+            </label>
           </div>
         </div>
 
@@ -313,6 +399,20 @@ const GlobalMap = () => {
               </button>
             ))}
           </div>
+          {showAssets && (
+            <select value={filterAssetCategory} onChange={e => setFilterAssetCategory(e.target.value)}
+              className="px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded dark:bg-slate-800 dark:text-gray-100">
+              <option value="">All asset categories</option>
+              {assetCategoryOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+            </select>
+          )}
+          {showTransactions && (
+            <select value={filterTxType} onChange={e => setFilterTxType(e.target.value)}
+              className="px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded dark:bg-slate-800 dark:text-gray-100">
+              <option value="">All transaction types</option>
+              {txTypeOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+            </select>
+          )}
         </div>
       </div>
 
@@ -325,7 +425,29 @@ const GlobalMap = () => {
               {markers.map(marker => (
                 <Marker key={marker.id} position={[marker.lat, marker.lng]} icon={marker.icon}>
                   <Popup>
-                    {marker.type === 'wireless_network' ? (
+                    {marker.kind === 'property' ? (
+                      <div className="p-2 min-w-[200px]">
+                        <h3 className="font-semibold text-emerald-600 dark:text-emerald-400 flex items-center"><Landmark className="w-4 h-4 mr-2" />{marker.name}</h3>
+                        {marker.propertyType && <p className="text-xs text-gray-600 dark:text-gray-400 capitalize">{marker.propertyType.replace(/_/g, ' ')}</p>}
+                        {marker.address && <p className="text-sm text-gray-800 dark:text-gray-200 mt-1">{marker.address}</p>}
+                        {marker.ownerName && marker.ownerName.trim() && <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">Owner: {marker.ownerName}</p>}
+                      </div>
+                    ) : marker.kind === 'asset' ? (
+                      <div className="p-2 min-w-[200px]">
+                        <h3 className="font-semibold text-orange-600 dark:text-orange-400 flex items-center"><Package className="w-4 h-4 mr-2" />{marker.name}</h3>
+                        {marker.assetCategory && <p className="text-xs text-gray-600 dark:text-gray-400 capitalize">{marker.assetCategory.replace(/_/g, ' ')}</p>}
+                        <p className="text-sm text-gray-800 dark:text-gray-200 mt-1">Holder: {marker.holderName || '—'}</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">{marker.locLabel} ({(marker.locationMode || '').replace(/_/g, ' ')})</p>
+                      </div>
+                    ) : marker.kind === 'transaction' ? (
+                      <div className="p-2 min-w-[200px]">
+                        <h3 className="font-semibold text-blue-600 dark:text-blue-400 flex items-center capitalize"><Receipt className="w-4 h-4 mr-2" />{(marker.txType || '').replace(/_/g, ' ')}</h3>
+                        <p className="text-sm text-gray-800 dark:text-gray-200 mt-1">{marker.fromLabel || '—'} → {marker.toLabel || '—'}</p>
+                        {marker.subjectLabel && <p className="text-xs text-gray-600 dark:text-gray-400">Subject: {marker.subjectLabel}</p>}
+                        {marker.value != null && <p className="text-xs text-gray-600 dark:text-gray-400">Value: {marker.value} {marker.currency || ''}</p>}
+                        {marker.locLabel && <p className="text-xs text-gray-500 dark:text-gray-400">{marker.locLabel}</p>}
+                      </div>
+                    ) : marker.type === 'wireless_network' ? (
                       <div className="p-2 min-w-[200px]">
                         <h3 className="font-semibold text-blue-600 dark:text-blue-400 flex items-center">
                           <Wifi className="w-4 h-4 mr-2" />{marker.ssid}

--- a/frontend/src/components/PersonDetailModal.js
+++ b/frontend/src/components/PersonDetailModal.js
@@ -5,18 +5,31 @@ import { User, Edit2, X, Database, Mail, Phone, Globe, MapPin, Hash, Link, Calen
 import RelationshipManager from './visualization/RelationshipManager';
 import ReportGenerator from './ReportGenerator';
 import TravelPatternAnalysis from './TravelPatternAnalysis';
+import TransactionTable from './TransactionTable';
+import EntityLedger from './EntityLedger';
+import { transactionsAPI, assetsAPI } from '../utils/api';
 import { useData } from '../contexts/DataContext';
 import { useUI } from '../contexts/UIContext';
 
 const PersonDetailModal = () => {
   const { people, customFields } = useData();
-  const { selectedPersonForDetail: person, setSelectedPersonForDetail, setEditingPerson } = useUI();
+  const { selectedPersonForDetail, setSelectedPersonForDetail, setEditingPerson } = useUI();
+  // Resolve full record (callers may pass a partial { id }).
+  const person = (selectedPersonForDetail && people.find(p => p.id === selectedPersonForDetail.id)) || selectedPersonForDetail;
 
   const onClose = () => setSelectedPersonForDetail(null);
   const onEdit = (p) => { setSelectedPersonForDetail(null); setEditingPerson(p); };
   const [activeTab, setActiveTab] = useState('details');
   const [showReportGenerator, setShowReportGenerator] = useState(false);
   const [locations, setLocations] = useState(person.locations || []);
+  const [personTransactions, setPersonTransactions] = useState([]);
+  const [personAssets, setPersonAssets] = useState([]);
+
+  useEffect(() => {
+    if (!person?.id) return;
+    transactionsAPI.getByPerson(person.id).then(r => setPersonTransactions(r.data || [])).catch(err => console.error('Error loading person transactions:', err));
+    assetsAPI.getByPerson(person.id).then(r => setPersonAssets(r.data || [])).catch(err => console.error('Error loading person assets:', err));
+  }, [person?.id]);
 
   const handleDeleteLocation = async (index) => {
     if (!window.confirm('Remove this location?')) return;
@@ -163,7 +176,7 @@ const PersonDetailModal = () => {
           {/* Tabs */}
           <div className="border-b border-gray-200 dark:border-gray-700">
             <div className="flex">
-            {['details', 'relationships', 'locations', 'travel'].map((tab) => (
+            {['details', 'relationships', 'locations', 'travel', 'transactions', 'assets', 'ledger'].map((tab) => (
                <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
@@ -393,10 +406,47 @@ const PersonDetailModal = () => {
             
             {activeTab === 'travel' && (
               <div className="p-6">
-                <TravelPatternAnalysis 
-                  personId={person.id} 
+                <TravelPatternAnalysis
+                  personId={person.id}
                   personName={getFullName(person)}
                 />
+              </div>
+            )}
+
+            {activeTab === 'transactions' && (
+              <div className="p-6 space-y-6">
+                <div>
+                  <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100">Received</h3>
+                  <TransactionTable transactions={personTransactions.filter(t => t.direction === 'received')} emptyText="Nothing received." />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100">Given</h3>
+                  <TransactionTable transactions={personTransactions.filter(t => t.direction === 'given')} emptyText="Nothing given." />
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'assets' && (
+              <div className="p-6">
+                <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100">Assets Currently Held</h3>
+                {personAssets.length === 0 ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">No assets currently held.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {personAssets.map(a => (
+                      <div key={a.id} className="flex justify-between items-center p-3 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+                        <span className="text-gray-800 dark:text-gray-200 font-medium">{a.name}</span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400 capitalize">{[a.category, a.status].filter(Boolean).join(' · ')}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {activeTab === 'ledger' && (
+              <div className="p-6">
+                <EntityLedger entityType="people" entityId={person.id} />
               </div>
             )}
           </div>

--- a/frontend/src/components/PropertyDetailModal.js
+++ b/frontend/src/components/PropertyDetailModal.js
@@ -1,0 +1,79 @@
+// File: frontend/src/components/PropertyDetailModal.js
+import React, { useState, useEffect } from 'react';
+import { Landmark, X, Edit2, MapPin, User, FileText } from 'lucide-react';
+import { propertiesAPI } from '../utils/api';
+import { useUI } from '../contexts/UIContext';
+import ChainOfCustodyTimeline from './ChainOfCustodyTimeline';
+import TransactionTable from './TransactionTable';
+import EntityLedger from './EntityLedger';
+import ReportGenerator from './ReportGenerator';
+
+const PropertyDetailModal = ({ property: initial, onClose }) => {
+  const { setEditingProperty } = useUI();
+  const [property, setProperty] = useState(initial);
+  const [tab, setTab] = useState('details');
+  const [showReport, setShowReport] = useState(false);
+
+  useEffect(() => {
+    propertiesAPI.getById(initial.id).then(setProperty).catch(err => console.error('Error loading property:', err));
+  }, [initial.id]);
+
+  const tabs = ['details', 'custody', 'activity', 'ledger'];
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+          <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+            <div className="flex items-center space-x-3">
+              <div className="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                <Landmark className="w-6 h-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">{property.name}</h2>
+                {property.property_type && <p className="text-sm text-gray-500 dark:text-gray-400 capitalize">{property.property_type.replace(/_/g, ' ')}</p>}
+              </div>
+            </div>
+            <div className="flex space-x-2">
+              <button onClick={() => setShowReport(true)} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-green-600 dark:text-green-400 hover:bg-green-600 hover:text-white" title="Ledger report"><FileText className="w-5 h-5" /></button>
+              <button onClick={() => { onClose(); setEditingProperty(property); }} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white"><Edit2 className="w-5 h-5" /></button>
+              <button onClick={onClose} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-red-600 hover:text-white"><X className="w-5 h-5" /></button>
+            </div>
+          </div>
+
+          <div className="border-b border-gray-200 dark:border-gray-700 flex">
+            {tabs.map(t => (
+              <button key={t} onClick={() => setTab(t)} className={`px-5 py-3 text-sm font-medium capitalize border-b-2 ${tab === t ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`}>{t}</button>
+            ))}
+          </div>
+
+          <div className="overflow-y-auto p-5" style={{ maxHeight: 'calc(90vh - 170px)' }}>
+            {tab === 'details' && (
+              <div className="space-y-4 text-sm">
+                {(property.address || property.city) && (
+                  <div className="flex items-start text-gray-700 dark:text-gray-300"><MapPin className="w-4 h-4 mr-2 mt-0.5 text-gray-400" /><span>{[property.address, property.city, property.state, property.country, property.postal_code].filter(Boolean).join(', ')}</span></div>
+                )}
+                {property.owner_name && property.owner_name.trim() && (
+                  <div className="flex items-center text-gray-700 dark:text-gray-300"><User className="w-4 h-4 mr-2 text-gray-400" />Quick owner: {property.owner_name}</div>
+                )}
+                {property.derived_current_owner && (
+                  <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-300">
+                    Derived current owner: <strong>{property.derived_current_owner.label}</strong>{property.derived_owner_since ? ` (since ${new Date(property.derived_owner_since).toLocaleDateString()})` : ''}
+                  </div>
+                )}
+                {property.description && <div><h4 className="font-semibold text-gray-900 dark:text-white mb-1">Description</h4><p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{property.description}</p></div>}
+                {property.notes && <div><h4 className="font-semibold text-gray-900 dark:text-white mb-1">Notes</h4><p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{property.notes}</p></div>}
+              </div>
+            )}
+            {tab === 'custody' && <ChainOfCustodyTimeline chain={property.chain_of_custody || []} emptyText="No ownership history yet." />}
+            {tab === 'activity' && <TransactionTable transactions={property.venue_transactions || []} emptyText="No events recorded at this property." />}
+            {tab === 'ledger' && <EntityLedger entityType="properties" entityId={property.id} />}
+          </div>
+        </div>
+      </div>
+      {showReport && <ReportGenerator ledgerEntity={{ type: 'properties', id: property.id, label: property.name }} onClose={() => setShowReport(false)} />}
+    </>
+  );
+};
+
+export default PropertyDetailModal;

--- a/frontend/src/components/PropertyList.js
+++ b/frontend/src/components/PropertyList.js
@@ -1,0 +1,145 @@
+// File: frontend/src/components/PropertyList.js
+import React, { useState, useEffect, useCallback, memo } from 'react';
+import { FixedSizeList } from 'react-window';
+import { Landmark, Search, Plus, Edit2, Trash2, Eye, MapPin, Tag, User } from 'lucide-react';
+import { propertiesAPI, modelOptionsAPI } from '../utils/api';
+import { useData } from '../contexts/DataContext';
+import { useUI } from '../contexts/UIContext';
+
+const VIRTUAL_THRESHOLD = 150;
+const ITEM_HEIGHT = 150;
+
+const PropertyList = () => {
+  const { properties, fetchProperties, propertiesMeta, loadMoreProperties } = useData();
+  const { setShowAddPropertyForm, setEditingProperty, setSelectedPropertyForDetail } = useUI();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterType, setFilterType] = useState('');
+  const [typeOptions, setTypeOptions] = useState([]);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    modelOptionsAPI.getAll()
+      .then(data => setTypeOptions(data.filter(o => o.model_type === 'property_type' && o.is_active)))
+      .catch(err => console.error('Error loading property types:', err));
+  }, []);
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this property?')) return;
+    try {
+      await propertiesAPI.remove(id);
+      fetchProperties(0);
+    } catch (err) {
+      alert('Failed to delete property: ' + err.message);
+    }
+  };
+
+  const filtered = properties.filter(p => {
+    const matchesSearch = searchTerm === '' ||
+      (p.name && p.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
+      (p.address && p.address.toLowerCase().includes(searchTerm.toLowerCase())) ||
+      (p.city && p.city.toLowerCase().includes(searchTerm.toLowerCase()));
+    const matchesType = filterType === '' || p.property_type === filterType;
+    return matchesSearch && matchesType;
+  });
+
+  const Card = ({ property }) => (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg p-5 hover:shadow-md transition-shadow duration-150 group">
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex items-center space-x-3 min-w-0">
+          <div className="w-11 h-11 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+            <Landmark className="w-6 h-6 text-emerald-600 dark:text-emerald-400" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">{property.name}</h3>
+            {property.property_type && (
+              <span className="inline-flex items-center text-xs px-2 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300 capitalize">
+                {property.property_type.replace(/_/g, ' ')}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+          <button onClick={() => setSelectedPropertyForDetail(property)} className="p-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white transition-colors" title="View"><Eye className="w-4 h-4" /></button>
+          <button onClick={() => setEditingProperty(property)} className="p-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-600 hover:text-white transition-colors" title="Edit"><Edit2 className="w-4 h-4" /></button>
+          <button onClick={() => handleDelete(property.id)} className="p-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-red-600 dark:text-red-400 hover:bg-red-600 hover:text-white transition-colors" title="Delete"><Trash2 className="w-4 h-4" /></button>
+        </div>
+      </div>
+      <div className="space-y-1.5 text-sm">
+        {(property.address || property.city) && (
+          <div className="flex items-center text-gray-700 dark:text-gray-300">
+            <MapPin className="w-4 h-4 mr-2 text-gray-400" />
+            <span className="truncate">{[property.address, property.city, property.country].filter(Boolean).join(', ')}</span>
+          </div>
+        )}
+        {property.owner_name && property.owner_name.trim() && (
+          <div className="flex items-center text-gray-700 dark:text-gray-300">
+            <User className="w-4 h-4 mr-2 text-gray-400" />
+            <span>Owner: {property.owner_name}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderVirtual = useCallback(({ index, style }) => (
+    <div style={{ ...style, paddingBottom: 16 }}><Card property={filtered[index]} /></div>
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [filtered]);
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Properties</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-2 flex items-center">
+            <Landmark className="w-5 h-5 mr-2 text-emerald-600 dark:text-emerald-400" />
+            <span className="font-medium">{properties.length}{propertiesMeta.total > properties.length ? ` of ${propertiesMeta.total}` : ''} properties</span>
+          </p>
+        </div>
+        <button onClick={() => setShowAddPropertyForm(true)} className="px-6 py-3 bg-blue-600 text-white dark:bg-blue-500 rounded-lg hover:shadow-glow-md transition flex items-center active:scale-[0.97]">
+          <Plus className="w-5 h-5 mr-2" />Add Property
+        </button>
+      </div>
+
+      <div className="mb-6 flex space-x-4">
+        <div className="flex-1 max-w-md relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-blue-600 dark:text-blue-400 w-5 h-5" />
+          <input type="text" placeholder="Search by name, address, city…" value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500" />
+        </div>
+        <select value={filterType} onChange={(e) => setFilterType(e.target.value)}
+          className="px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-800 dark:text-white">
+          <option value="">All Types</option>
+          {typeOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <Landmark className="w-12 h-12 text-gray-400 mx-auto mb-3" />
+          <p className="text-gray-600 dark:text-gray-400">No properties found.</p>
+        </div>
+      ) : filtered.length >= VIRTUAL_THRESHOLD ? (
+        <FixedSizeList height={Math.min(filtered.length * ITEM_HEIGHT, 700)} itemCount={filtered.length} itemSize={ITEM_HEIGHT} width="100%" overscanCount={3}>
+          {renderVirtual}
+        </FixedSizeList>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map(p => <Card key={p.id} property={p} />)}
+        </div>
+      )}
+
+      {propertiesMeta.hasMore && filtered.length === properties.length && (
+        <div className="flex flex-col items-center py-6 space-y-2">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Showing {properties.length} of {propertiesMeta.total}</p>
+          <button onClick={async () => { setLoadingMore(true); await loadMoreProperties(); setLoadingMore(false); }} disabled={loadingMore}
+            className="px-5 py-2.5 bg-blue-600 dark:bg-blue-500 text-white rounded-lg text-sm font-medium disabled:opacity-60">
+            {loadingMore ? 'Loading…' : `Load more (${propertiesMeta.total - properties.length} remaining)`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default memo(PropertyList);

--- a/frontend/src/components/RelationshipDiagram.js
+++ b/frontend/src/components/RelationshipDiagram.js
@@ -11,7 +11,8 @@ import ReactFlow, {
   MarkerType,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
-import { User, Database, Mail, Phone, Globe, MapPin, Hash, Link, UserPlus, X, Edit2, Save, AlertCircle, Trash2, Bug } from 'lucide-react';
+import { User, Database, Mail, Phone, Globe, MapPin, Hash, Link, UserPlus, X, Edit2, Save, AlertCircle, Trash2, Bug, Building2, Landmark, Network } from 'lucide-react';
+import { transactionsAPI } from '../utils/api';
 
 // Debug component to show data structure
 const DebugPanel = ({ people, nodes, edges, show }) => {
@@ -105,9 +106,33 @@ const PersonNode = ({ data, selected }) => {
   );
 };
 
+// Hub node for businesses / properties in the transaction layer (issue #43)
+const EntityNode = ({ data, selected }) => {
+  const isProperty = data.kind === 'property';
+  const Icon = isProperty ? Landmark : Building2;
+  return (
+    <>
+      <Handle type="target" position={Position.Top} style={{ background: '#555' }} />
+      <div className={`px-4 py-3 shadow-lg rounded-lg border-2 ${selected ? 'border-blue-500' : 'border-gray-300 dark:border-slate-600'} ${isProperty ? 'bg-emerald-50 dark:bg-emerald-900/30' : 'bg-indigo-50 dark:bg-indigo-900/30'} cursor-pointer min-w-[180px]`}>
+        <div className="flex items-center space-x-3">
+          <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-white flex-shrink-0 ${isProperty ? 'bg-emerald-600' : 'bg-indigo-600'}`}>
+            <Icon className="w-5 h-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate">{data.label}</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 capitalize">{data.kind}{data.eventCount ? ` · ${data.eventCount} event${data.eventCount !== 1 ? 's' : ''}` : ''}</div>
+          </div>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Bottom} style={{ background: '#555' }} />
+    </>
+  );
+};
+
 // Node type mapping
 const nodeTypes = {
   person: PersonNode,
+  entity: EntityNode,
 };
 
 // Edge styles
@@ -139,6 +164,15 @@ const RelationshipDiagram = ({
   const [connectionModal, setConnectionModal] = useState(null);
   const [connectionType, setConnectionType] = useState('associate');
   const [connectionNote, setConnectionNote] = useState('');
+  // Transaction/venue layer (issue #43)
+  const [showTransactionLayer, setShowTransactionLayer] = useState(false);
+  const [txData, setTxData] = useState([]);
+
+  useEffect(() => {
+    transactionsAPI.getAll({ limit: 1000 })
+      .then(r => setTxData(r.data || []))
+      .catch(err => console.error('Error loading transactions for graph:', err));
+  }, []);
 
   // Helper function to get full name
   const getFullName = (person) => {
@@ -351,9 +385,56 @@ const RelationshipDiagram = ({
       });
     });
     
+    // Transaction/venue layer: businesses & properties as hubs, edges to parties.
+    if (showTransactionLayer && txData.length > 0) {
+      const nodeIds = new Set(newNodes.map(n => n.id));
+      const ensureEntity = (kind, id, label) => {
+        const nid = `${kind === 'business' ? 'biz' : 'prop'}-${id}`;
+        if (!nodeIds.has(nid)) {
+          newNodes.push({ id: nid, type: 'entity', position: { x: 0, y: 0 }, data: { label: label || `${kind} #${id}`, kind, eventCount: 0 } });
+          nodeIds.add(nid);
+        }
+        return nid;
+      };
+      const txEdgeMap = new Map();
+      txData.forEach(t => {
+        const hubs = [];
+        if (t.location_business_id) hubs.push(ensureEntity('business', t.location_business_id, t.resolved_location?.label));
+        if (t.location_property_id) hubs.push(ensureEntity('property', t.location_property_id, t.resolved_location?.label));
+        if (t.subject_business_id) hubs.push(ensureEntity('business', t.subject_business_id, t.resolved_subject?.label));
+        if (t.subject_property_id) hubs.push(ensureEntity('property', t.subject_property_id, t.resolved_subject?.label));
+        if (hubs.length === 0) return;
+        const spokes = [];
+        [t.resolved_from, t.resolved_to].forEach(party => {
+          if (!party) return;
+          if (party.type === 'person') { const nid = `person-${party.id}`; if (nodeIds.has(nid)) spokes.push(nid); }
+          else if (party.type === 'business') spokes.push(ensureEntity('business', party.id, party.label));
+        });
+        hubs.forEach(hub => {
+          const hubNode = newNodes.find(n => n.id === hub);
+          if (hubNode) hubNode.data.eventCount = (hubNode.data.eventCount || 0) + 1;
+          spokes.forEach(spoke => {
+            if (spoke === hub) return;
+            const key = `${hub}|${spoke}`;
+            txEdgeMap.set(key, (txEdgeMap.get(key) || 0) + 1);
+          });
+        });
+      });
+      txEdgeMap.forEach((count, key) => {
+        const [hub, spoke] = key.split('|');
+        newEdges.push({
+          id: `txedge-${hub}-${spoke}`, source: hub, target: spoke, type: 'straight',
+          label: count > 1 ? String(count) : undefined,
+          style: { stroke: '#0891b2', strokeWidth: Math.min(8, 1 + count), strokeDasharray: '4 3', cursor: 'default' },
+          labelStyle: { fontSize: 10, fill: '#0e7490' },
+          data: { txLayer: true },
+        });
+      });
+    }
+
     console.log(`Total nodes created: ${newNodes.length}`);
     console.log(`Total edges created: ${newEdges.length}`);
-    
+
     // Apply layout
     const layoutedNodes = applyLayout(newNodes, newEdges, layoutType);
     
@@ -361,7 +442,7 @@ const RelationshipDiagram = ({
     setNodes(layoutedNodes);
     setEdges(newEdges);
     
-  }, [people, layoutType, setNodes, setEdges, applyLayout]);
+  }, [people, layoutType, setNodes, setEdges, applyLayout, showTransactionLayer, txData]);
 
   // Handle connection creation
   const onConnect = useCallback((params) => {
@@ -450,9 +531,9 @@ const RelationshipDiagram = ({
   const onEdgeClick = useCallback((event, edge) => {
     console.log('Edge clicked:', edge);
     event.stopPropagation();
-    
-    if (!edge.data) return;
-    
+
+    if (!edge.data || edge.data.txLayer) return;
+
     const confirmed = window.confirm(
       `Delete connection between ${edge.source} and ${edge.target}?\n` +
       `Type: ${edge.data.type || 'Unknown'}\n` +
@@ -503,6 +584,15 @@ const RelationshipDiagram = ({
               <span>Connect</span>
             </button>
           )}
+
+          <button
+            onClick={() => setShowTransactionLayer(v => !v)}
+            className={`px-3 py-2 rounded-md text-sm font-medium flex items-center space-x-2 ${showTransactionLayer ? 'bg-cyan-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+            title="Toggle transaction / venue layer"
+          >
+            <Network className="w-4 h-4" />
+            <span>{showTransactionLayer ? 'Hide' : 'Show'} Venues</span>
+          </button>
         </div>
         
         {isAddingConnection && (

--- a/frontend/src/components/ReportGenerator.js
+++ b/frontend/src/components/ReportGenerator.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { FileText, Download, Loader2, X } from 'lucide-react';
-import { peopleAPI, casesAPI, todosAPI, businessesAPI, locationsAPI } from '../utils/api';
-import { downloadMarkdown, downloadWord } from '../utils/reportGenerators';
+import { peopleAPI, casesAPI, todosAPI, businessesAPI, locationsAPI, ledgerAPI } from '../utils/api';
+import { downloadMarkdown, downloadWord, downloadLedgerMarkdown, downloadLedgerWord } from '../utils/reportGenerators';
 import ReportOptions from './reports/ReportOptions';
 import ReportPreview from './reports/ReportPreview';
+import LedgerReportPanel from './reports/LedgerReportPanel';
 
 const DEFAULT_OPTIONS = {
   includeSummary: true,
@@ -19,19 +20,34 @@ const DEFAULT_OPTIONS = {
   dateRange: 'all',
 };
 
-const ReportGenerator = ({ caseId = null, personId = null, customPeopleIds = null, onClose }) => {
+const ReportGenerator = ({ caseId = null, personId = null, customPeopleIds = null, ledgerEntity = null, onClose }) => {
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [reportOptions, setReportOptions] = useState(DEFAULT_OPTIONS);
+  const [ledger, setLedger] = useState(null);
   const [data, setData] = useState({
     cases: [], people: [], businesses: [], locations: [], todos: [],
     selectedCase: null, selectedPerson: null,
   });
 
   useEffect(() => {
-    fetchData();
+    if (ledgerEntity) fetchLedger();
+    else fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [caseId, personId]);
+  }, [caseId, personId, ledgerEntity]);
+
+  const fetchLedger = async () => {
+    setLoading(true);
+    try {
+      const data = await ledgerAPI.get(ledgerEntity.type, ledgerEntity.id);
+      setLedger(data);
+    } catch (error) {
+      console.error('Error fetching ledger:', error);
+      alert('Failed to fetch ledger for report');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const fetchData = async () => {
     setLoading(true);
@@ -80,7 +96,8 @@ const ReportGenerator = ({ caseId = null, personId = null, customPeopleIds = nul
   const handleDownloadMarkdown = async () => {
     setGenerating(true);
     try {
-      downloadMarkdown(data, reportOptions);
+      if (ledgerEntity) downloadLedgerMarkdown(ledger);
+      else downloadMarkdown(data, reportOptions);
     } catch (error) {
       console.error('Error generating Markdown report:', error);
       alert('Failed to generate Markdown report: ' + error.message);
@@ -92,7 +109,8 @@ const ReportGenerator = ({ caseId = null, personId = null, customPeopleIds = nul
   const handleDownloadWord = async () => {
     setGenerating(true);
     try {
-      await downloadWord(data, reportOptions);
+      if (ledgerEntity) await downloadLedgerWord(ledger);
+      else await downloadWord(data, reportOptions);
     } catch (error) {
       console.error('Error generating Word report:', error);
       alert('Failed to generate Word report: ' + error.message);
@@ -109,7 +127,7 @@ const ReportGenerator = ({ caseId = null, personId = null, customPeopleIds = nul
         <div className="px-6 py-4 border-b border-gray-200 dark:border-slate-700 flex items-center justify-between shrink-0">
           <div className="flex items-center gap-3">
             <FileText className="w-5 h-5 text-blue-600" />
-            <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">Generate Investigation Report</h2>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-slate-100">{ledgerEntity ? 'Generate Entity Ledger Report' : 'Generate Investigation Report'}</h2>
           </div>
           <button
             onClick={onClose}
@@ -127,10 +145,14 @@ const ReportGenerator = ({ caseId = null, personId = null, customPeopleIds = nul
           </div>
         ) : (
           <div className="flex-1 overflow-y-auto p-6">
-            <div className="grid grid-cols-2 gap-8">
-              <ReportOptions reportOptions={reportOptions} onChange={setReportOptions} />
-              <ReportPreview data={data} reportOptions={reportOptions} />
-            </div>
+            {ledgerEntity ? (
+              <LedgerReportPanel ledger={ledger} />
+            ) : (
+              <div className="grid grid-cols-2 gap-8">
+                <ReportOptions reportOptions={reportOptions} onChange={setReportOptions} />
+                <ReportPreview data={data} reportOptions={reportOptions} />
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/TransactionDetailModal.js
+++ b/frontend/src/components/TransactionDetailModal.js
@@ -1,0 +1,70 @@
+// File: frontend/src/components/TransactionDetailModal.js
+import React, { useState, useEffect } from 'react';
+import { Receipt, X, Edit2, ArrowRight, MapPin, Calendar, FileText } from 'lucide-react';
+import { transactionsAPI } from '../utils/api';
+import { useUI } from '../contexts/UIContext';
+import { formatDate, formatMoney, partyText, subjectText, prettyType, typeBadgeClass } from '../utils/transactionFormat';
+
+const Field = ({ label, children }) => (
+  <div className="flex justify-between gap-4 py-1.5 border-b border-gray-100 dark:border-gray-700/50 last:border-0">
+    <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
+    <span className="text-sm text-gray-900 dark:text-gray-100 text-right">{children}</span>
+  </div>
+);
+
+const TransactionDetailModal = ({ transaction: initial, onClose }) => {
+  const { setEditingTransaction } = useUI();
+  const [t, setT] = useState(initial);
+
+  useEffect(() => {
+    transactionsAPI.getById(initial.id).then(setT).catch(err => console.error('Error loading transaction:', err));
+  }, [initial.id]);
+
+  const loc = t.resolved_location;
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-5 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <div className="flex items-center space-x-3">
+            <div className="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center"><Receipt className="w-6 h-6 text-blue-600 dark:text-blue-400" /></div>
+            <div>
+              <span className={`text-xs px-2 py-0.5 rounded capitalize ${typeBadgeClass(t.transaction_type)}`}>{prettyType(t.transaction_type)}</span>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white mt-1">{subjectText(t.resolved_subject)}</h2>
+            </div>
+          </div>
+          <div className="flex space-x-2">
+            <button onClick={() => { onClose(); setEditingTransaction(t); }} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white"><Edit2 className="w-5 h-5" /></button>
+            <button onClick={onClose} className="p-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-red-600 hover:text-white"><X className="w-5 h-5" /></button>
+          </div>
+        </div>
+        <div className="overflow-y-auto p-5 space-y-4">
+          <div className="flex items-center justify-center text-base text-gray-900 dark:text-gray-100 py-2">
+            <span>{partyText(t.resolved_from)}</span>
+            <ArrowRight className="w-4 h-4 mx-3 text-gray-400" />
+            <span className="font-semibold">{partyText(t.resolved_to)}</span>
+          </div>
+          <div>
+            <Field label="Date"><span className="inline-flex items-center"><Calendar className="w-3.5 h-3.5 mr-1 text-gray-400" />{formatDate(t.occurred_on)}</span></Field>
+            <Field label="Value">{formatMoney(t.value, t.currency)}</Field>
+            <Field label="Subject">{subjectText(t.resolved_subject)}{t.resolved_subject?.type && t.resolved_subject.type !== 'item' ? ` (${t.resolved_subject.type})` : ''}</Field>
+            {t.item_category && <Field label="Item category">{prettyType(t.item_category)}</Field>}
+            <Field label="Location">
+              {loc && loc.type !== 'none' ? (
+                <span className="inline-flex items-center"><MapPin className="w-3.5 h-3.5 mr-1 text-gray-400" />{loc.label || prettyType(loc.type)}</span>
+              ) : '—'}
+            </Field>
+          </div>
+          {t.notes && (
+            <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700">
+              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 flex items-center"><FileText className="w-3 h-3 mr-1" />Notes</div>
+              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{t.notes}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TransactionDetailModal;

--- a/frontend/src/components/TransactionTable.js
+++ b/frontend/src/components/TransactionTable.js
@@ -1,0 +1,46 @@
+// File: frontend/src/components/TransactionTable.js
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { formatDate, formatMoney, partyText, subjectText, prettyType, typeBadgeClass } from '../utils/transactionFormat';
+import { useUI } from '../contexts/UIContext';
+
+// Compact table for an array of decorated transactions (resolved_* fields present).
+const TransactionTable = ({ transactions = [], emptyText = 'No transactions.', showRole = false }) => {
+  const { setSelectedTransactionForDetail } = useUI();
+  if (!transactions.length) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">{emptyText}</p>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+            <th className="py-2 pr-3 font-medium">Date</th>
+            <th className="py-2 pr-3 font-medium">Type</th>
+            {showRole && <th className="py-2 pr-3 font-medium">Role</th>}
+            <th className="py-2 pr-3 font-medium">From → To</th>
+            <th className="py-2 pr-3 font-medium">Subject</th>
+            <th className="py-2 pr-3 font-medium text-right">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map(t => (
+            <tr key={t.id} onClick={() => setSelectedTransactionForDetail(t)}
+              className="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/40 cursor-pointer">
+              <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">{formatDate(t.occurred_on)}</td>
+              <td className="py-2 pr-3"><span className={`text-xs px-2 py-0.5 rounded capitalize ${typeBadgeClass(t.transaction_type)}`}>{prettyType(t.transaction_type)}</span></td>
+              {showRole && <td className="py-2 pr-3 text-gray-600 dark:text-gray-400 capitalize">{prettyType(t.role)}</td>}
+              <td className="py-2 pr-3 text-gray-800 dark:text-gray-200">
+                <span className="inline-flex items-center">{partyText(t.resolved_from)}<ArrowRight className="w-3 h-3 mx-1 text-gray-400" />{partyText(t.resolved_to)}</span>
+              </td>
+              <td className="py-2 pr-3 text-gray-700 dark:text-gray-300">{subjectText(t.resolved_subject)}</td>
+              <td className="py-2 pr-3 text-right text-gray-800 dark:text-gray-200 whitespace-nowrap">{formatMoney(t.value, t.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default TransactionTable;

--- a/frontend/src/components/TransactionsList.js
+++ b/frontend/src/components/TransactionsList.js
@@ -1,0 +1,117 @@
+// File: frontend/src/components/TransactionsList.js
+import React, { useState, useEffect, useCallback, memo } from 'react';
+import { FixedSizeList } from 'react-window';
+import { Receipt, Search, Plus, Edit2, Trash2, Eye, ArrowRight } from 'lucide-react';
+import { transactionsAPI, modelOptionsAPI } from '../utils/api';
+import { useData } from '../contexts/DataContext';
+import { useUI } from '../contexts/UIContext';
+import { formatDate, formatMoney, partyText, subjectText, prettyType, typeBadgeClass } from '../utils/transactionFormat';
+
+const VIRTUAL_THRESHOLD = 150;
+const ROW_HEIGHT = 64;
+
+const TransactionsList = () => {
+  const { transactions, fetchTransactions, transactionsMeta, loadMoreTransactions } = useData();
+  const { setShowAddTransactionForm, setEditingTransaction, setSelectedTransactionForDetail } = useUI();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterType, setFilterType] = useState('');
+  const [typeOptions, setTypeOptions] = useState([]);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    modelOptionsAPI.getAll().then(d => setTypeOptions(d.filter(o => o.model_type === 'transaction_type' && o.is_active))).catch(() => {});
+  }, []);
+
+  const handleDelete = async (id, e) => {
+    e.stopPropagation();
+    if (!window.confirm('Delete this transaction?')) return;
+    try { await transactionsAPI.remove(id); fetchTransactions(0); }
+    catch (err) { alert('Failed to delete: ' + err.message); }
+  };
+
+  const filtered = transactions.filter(t => {
+    const matchesType = filterType === '' || t.transaction_type === filterType;
+    const hay = [t.item_label, partyText(t.resolved_from), partyText(t.resolved_to), subjectText(t.resolved_subject)].join(' ').toLowerCase();
+    const matchesSearch = searchTerm === '' || hay.includes(searchTerm.toLowerCase());
+    return matchesType && matchesSearch;
+  });
+
+  const Row = ({ t }) => (
+    <div onClick={() => setSelectedTransactionForDetail(t)}
+      className="flex items-center gap-3 px-4 py-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md transition cursor-pointer group">
+      <span className="text-xs text-gray-500 dark:text-gray-400 w-24 flex-shrink-0">{formatDate(t.occurred_on)}</span>
+      <span className={`text-xs px-2 py-0.5 rounded capitalize flex-shrink-0 ${typeBadgeClass(t.transaction_type)}`}>{prettyType(t.transaction_type)}</span>
+      <span className="flex items-center text-sm text-gray-800 dark:text-gray-200 min-w-0 flex-1">
+        <span className="truncate">{partyText(t.resolved_from)}</span>
+        <ArrowRight className="w-3 h-3 mx-1 text-gray-400 flex-shrink-0" />
+        <span className="truncate font-medium">{partyText(t.resolved_to)}</span>
+      </span>
+      <span className="text-sm text-gray-600 dark:text-gray-400 truncate hidden md:block w-40">{subjectText(t.resolved_subject)}</span>
+      <span className="text-sm text-gray-800 dark:text-gray-200 w-28 text-right flex-shrink-0">{formatMoney(t.value, t.currency)}</span>
+      <span className="flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+        <button onClick={(e) => { e.stopPropagation(); setSelectedTransactionForDetail(t); }} className="p-1.5 rounded border border-gray-200 dark:border-gray-600 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white"><Eye className="w-4 h-4" /></button>
+        <button onClick={(e) => { e.stopPropagation(); setEditingTransaction(t); }} className="p-1.5 rounded border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-600 hover:text-white"><Edit2 className="w-4 h-4" /></button>
+        <button onClick={(e) => handleDelete(t.id, e)} className="p-1.5 rounded border border-gray-200 dark:border-gray-600 text-red-600 dark:text-red-400 hover:bg-red-600 hover:text-white"><Trash2 className="w-4 h-4" /></button>
+      </span>
+    </div>
+  );
+
+  const renderVirtual = useCallback(({ index, style }) => (
+    <div style={{ ...style, paddingBottom: 8 }}><Row t={filtered[index]} /></div>
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [filtered]);
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Transactions</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-2 flex items-center">
+            <Receipt className="w-5 h-5 mr-2 text-blue-600 dark:text-blue-400" />
+            <span className="font-medium">{transactions.length}{transactionsMeta.total > transactions.length ? ` of ${transactionsMeta.total}` : ''} transactions</span>
+          </p>
+        </div>
+        <button onClick={() => setShowAddTransactionForm(true)} className="px-6 py-3 bg-blue-600 text-white dark:bg-blue-500 rounded-lg hover:shadow-glow-md transition flex items-center active:scale-[0.97]">
+          <Plus className="w-5 h-5 mr-2" />Add Transaction
+        </button>
+      </div>
+
+      <div className="mb-6 flex space-x-4">
+        <div className="flex-1 max-w-md relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-blue-600 dark:text-blue-400 w-5 h-5" />
+          <input type="text" placeholder="Search party, subject…" value={searchTerm} onChange={e => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500" />
+        </div>
+        <select value={filterType} onChange={e => setFilterType(e.target.value)} className="px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-800 dark:text-white">
+          <option value="">All Types</option>
+          {typeOptions.map(o => <option key={o.id} value={o.option_value}>{o.option_label}</option>)}
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <Receipt className="w-12 h-12 text-gray-400 mx-auto mb-3" />
+          <p className="text-gray-600 dark:text-gray-400">No transactions found.</p>
+        </div>
+      ) : filtered.length >= VIRTUAL_THRESHOLD ? (
+        <FixedSizeList height={700} itemCount={filtered.length} itemSize={ROW_HEIGHT} width="100%" overscanCount={5}>
+          {renderVirtual}
+        </FixedSizeList>
+      ) : (
+        <div className="space-y-2">{filtered.map(t => <Row key={t.id} t={t} />)}</div>
+      )}
+
+      {transactionsMeta.hasMore && filtered.length === transactions.length && (
+        <div className="flex flex-col items-center py-6 space-y-2">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Showing {transactions.length} of {transactionsMeta.total}</p>
+          <button onClick={async () => { setLoadingMore(true); await loadMoreTransactions(); setLoadingMore(false); }} disabled={loadingMore}
+            className="px-5 py-2.5 bg-blue-600 dark:bg-blue-500 text-white rounded-lg text-sm font-medium disabled:opacity-60">
+            {loadingMore ? 'Loading…' : `Load more (${transactionsMeta.total - transactions.length} remaining)`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default memo(TransactionsList);

--- a/frontend/src/components/reports/LedgerReportPanel.js
+++ b/frontend/src/components/reports/LedgerReportPanel.js
@@ -1,0 +1,55 @@
+// File: frontend/src/components/reports/LedgerReportPanel.js
+import React from 'react';
+import { formatDate, formatMoney, prettyType } from '../../utils/transactionFormat';
+
+// Printable preview of an entity ledger report (issue #43).
+const LedgerReportPanel = ({ ledger }) => {
+  if (!ledger) return null;
+  const { entity, entries, summary } = ledger;
+  return (
+    <div className="text-sm text-gray-800 dark:text-gray-200">
+      <h3 className="text-lg font-bold mb-1">Entity Ledger</h3>
+      <p className="text-gray-600 dark:text-gray-400 mb-3">{entity.label} ({entity.type})</p>
+
+      <div className="grid grid-cols-3 gap-2 mb-4">
+        <div className="p-2 rounded bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
+          <div className="text-xs text-green-700 dark:text-green-400">In</div>
+          <div className="font-bold text-green-700 dark:text-green-300">{summary.value_in != null ? formatMoney(summary.value_in) : 'mixed'}</div>
+        </div>
+        <div className="p-2 rounded bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+          <div className="text-xs text-red-700 dark:text-red-400">Out</div>
+          <div className="font-bold text-red-700 dark:text-red-300">{summary.value_out != null ? formatMoney(summary.value_out) : 'mixed'}</div>
+        </div>
+        <div className="p-2 rounded bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700">
+          <div className="text-xs text-gray-500 dark:text-gray-400">Net</div>
+          <div className="font-bold">{summary.net != null ? formatMoney(summary.net) : 'see per-currency'}</div>
+        </div>
+      </div>
+
+      <div className="max-h-64 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded">
+        <table className="min-w-full text-xs">
+          <thead className="bg-gray-50 dark:bg-gray-700/40">
+            <tr className="text-left">
+              <th className="p-2">Date</th><th className="p-2">Type</th><th className="p-2">Role</th><th className="p-2">Counterparty</th><th className="p-2 text-right">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 ? (
+              <tr><td colSpan={5} className="p-3 text-center text-gray-500 dark:text-gray-400">No entries.</td></tr>
+            ) : entries.map((e, i) => (
+              <tr key={`${e.transaction_id}-${e.role}-${i}`} className="border-t border-gray-100 dark:border-gray-700/50">
+                <td className="p-2 whitespace-nowrap">{formatDate(e.occurred_on)}</td>
+                <td className="p-2 capitalize">{prettyType(e.transaction_type)}</td>
+                <td className="p-2 capitalize">{prettyType(e.role)}</td>
+                <td className="p-2">{e.counterparty?.label || '—'}</td>
+                <td className="p-2 text-right">{e.value != null ? formatMoney(e.value, e.currency) : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default LedgerReportPanel;

--- a/frontend/src/components/settings/DataModelTab.js
+++ b/frontend/src/components/settings/DataModelTab.js
@@ -12,6 +12,11 @@ const MODEL_TYPE_LABELS = {
   connection_type: 'Connection Types',
   location_type: 'Location Types',
   osint_data_type: 'OSINT Data Types',
+  transaction_type: 'Transaction Types',
+  transaction_item_category: 'Transaction Item Categories',
+  asset_category: 'Asset Categories',
+  asset_status: 'Asset Statuses',
+  property_type: 'Property Types',
 };
 
 const EMPTY_FORM = { option_value: '', option_label: '', display_order: 999, is_active: true };

--- a/frontend/src/contexts/DataContext.js
+++ b/frontend/src/contexts/DataContext.js
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
-import { peopleAPI, businessAPI, toolsAPI, todosAPI, customFieldsAPI } from '../utils/api';
+import { peopleAPI, businessAPI, toolsAPI, todosAPI, customFieldsAPI, propertiesAPI, assetsAPI, transactionsAPI } from '../utils/api';
 import { DEFAULT_APP_SETTINGS } from '../utils/constants';
 
 const DataContext = createContext(null);
@@ -15,6 +15,18 @@ export const DataProvider = ({ children }) => {
   const [tools, setTools] = useState([]);
   const [todos, setTodos] = useState([]);
   const [customFields, setCustomFields] = useState([]);
+
+  // Transaction tracking slices (issue #43)
+  const [properties, setProperties] = useState([]);
+  const [propertiesMeta, setPropertiesMeta] = useState({ total: 0, hasMore: false });
+  const propertiesLoadedRef = useRef(0);
+  const [assets, setAssets] = useState([]);
+  const [assetsMeta, setAssetsMeta] = useState({ total: 0, hasMore: false });
+  const assetsLoadedRef = useRef(0);
+  const [transactions, setTransactions] = useState([]);
+  const [transactionsMeta, setTransactionsMeta] = useState({ total: 0, hasMore: false });
+  const transactionsLoadedRef = useRef(0);
+
   const [appSettings, setAppSettings] = useState(() => {
     try {
       const saved = localStorage.getItem('appSettings');
@@ -81,6 +93,42 @@ export const DataProvider = ({ children }) => {
     }
   }, []);
 
+  const fetchProperties = useCallback(async (offset = 0) => {
+    try {
+      const { data, meta } = await propertiesAPI.getAll({ limit: PAGE_SIZE, offset });
+      if (offset === 0) { setProperties(data); propertiesLoadedRef.current = data.length; }
+      else { setProperties(prev => [...prev, ...data]); propertiesLoadedRef.current += data.length; }
+      setPropertiesMeta({ total: meta.total, hasMore: meta.hasMore });
+    } catch (err) {
+      console.error('Error fetching properties:', err);
+    }
+  }, []);
+  const loadMoreProperties = useCallback(async () => { await fetchProperties(propertiesLoadedRef.current); }, [fetchProperties]);
+
+  const fetchAssets = useCallback(async (offset = 0) => {
+    try {
+      const { data, meta } = await assetsAPI.getAll({ limit: PAGE_SIZE, offset });
+      if (offset === 0) { setAssets(data); assetsLoadedRef.current = data.length; }
+      else { setAssets(prev => [...prev, ...data]); assetsLoadedRef.current += data.length; }
+      setAssetsMeta({ total: meta.total, hasMore: meta.hasMore });
+    } catch (err) {
+      console.error('Error fetching assets:', err);
+    }
+  }, []);
+  const loadMoreAssets = useCallback(async () => { await fetchAssets(assetsLoadedRef.current); }, [fetchAssets]);
+
+  const fetchTransactions = useCallback(async (offset = 0) => {
+    try {
+      const { data, meta } = await transactionsAPI.getAll({ limit: PAGE_SIZE, offset });
+      if (offset === 0) { setTransactions(data); transactionsLoadedRef.current = data.length; }
+      else { setTransactions(prev => [...prev, ...data]); transactionsLoadedRef.current += data.length; }
+      setTransactionsMeta({ total: meta.total, hasMore: meta.hasMore });
+    } catch (err) {
+      console.error('Error fetching transactions:', err);
+    }
+  }, []);
+  const loadMoreTransactions = useCallback(async () => { await fetchTransactions(transactionsLoadedRef.current); }, [fetchTransactions]);
+
   const refreshAll = useCallback(async () => {
     await Promise.all([
       fetchPeople(0),
@@ -88,8 +136,11 @@ export const DataProvider = ({ children }) => {
       fetchTools(),
       fetchTodos(),
       fetchCustomFields(),
+      fetchProperties(0),
+      fetchAssets(0),
+      fetchTransactions(0),
     ]);
-  }, [fetchPeople, fetchBusinesses, fetchTools, fetchTodos, fetchCustomFields]);
+  }, [fetchPeople, fetchBusinesses, fetchTools, fetchTodos, fetchCustomFields, fetchProperties, fetchAssets, fetchTransactions]);
 
   const handleAppNameChange = useCallback((newName) => {
     setAppSettings(prev => {
@@ -111,6 +162,9 @@ export const DataProvider = ({ children }) => {
       tools, setTools, fetchTools,
       todos, setTodos, fetchTodos,
       customFields, setCustomFields, fetchCustomFields,
+      properties, setProperties, fetchProperties, propertiesMeta, loadMoreProperties,
+      assets, setAssets, fetchAssets, assetsMeta, loadMoreAssets,
+      transactions, setTransactions, fetchTransactions, transactionsMeta, loadMoreTransactions,
       appSettings, setAppSettings: persistAppSettings, handleAppNameChange,
       refreshAll,
     }}>

--- a/frontend/src/contexts/UIContext.js
+++ b/frontend/src/contexts/UIContext.js
@@ -18,6 +18,24 @@ export const UIProvider = ({ children }) => {
   const [editingBusiness, setEditingBusiness] = useState(null);
   const [showAddBusinessForm, setShowAddBusinessForm] = useState(false);
 
+  // Property modals (issue #43)
+  const [selectedPropertyForDetail, setSelectedPropertyForDetail] = useState(null);
+  const [editingProperty, setEditingProperty] = useState(null);
+  const [showAddPropertyForm, setShowAddPropertyForm] = useState(false);
+
+  // Asset modals
+  const [selectedAssetForDetail, setSelectedAssetForDetail] = useState(null);
+  const [editingAsset, setEditingAsset] = useState(null);
+  const [showAddAssetForm, setShowAddAssetForm] = useState(false);
+
+  // Transaction modals
+  const [selectedTransactionForDetail, setSelectedTransactionForDetail] = useState(null);
+  const [editingTransaction, setEditingTransaction] = useState(null);
+  const [showAddTransactionForm, setShowAddTransactionForm] = useState(false);
+
+  // Business detail modal (issue #43 — venue activity / ledger surface)
+  const [selectedBusinessForDetail, setSelectedBusinessForDetail] = useState(null);
+
   // Other modals
   const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
 
@@ -31,6 +49,16 @@ export const UIProvider = ({ children }) => {
       showAddToolForm, setShowAddToolForm,
       editingBusiness, setEditingBusiness,
       showAddBusinessForm, setShowAddBusinessForm,
+      selectedPropertyForDetail, setSelectedPropertyForDetail,
+      editingProperty, setEditingProperty,
+      showAddPropertyForm, setShowAddPropertyForm,
+      selectedAssetForDetail, setSelectedAssetForDetail,
+      editingAsset, setEditingAsset,
+      showAddAssetForm, setShowAddAssetForm,
+      selectedTransactionForDetail, setSelectedTransactionForDetail,
+      editingTransaction, setEditingTransaction,
+      showAddTransactionForm, setShowAddTransactionForm,
+      selectedBusinessForDetail, setSelectedBusinessForDetail,
       showAdvancedSearch, setShowAdvancedSearch,
     }}>
       {children}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -414,4 +414,53 @@ export const wirelessNetworksAPI = {
   }),
 };
 
+// Helper to build a query string from a params object (skips empty values)
+const buildQuery = (params = {}) => {
+  const qp = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== null && value !== undefined && value !== '') qp.append(key, value);
+  });
+  const s = qp.toString();
+  return s ? `?${s}` : '';
+};
+
+// Properties API (transaction tracking — issue #43)
+export const propertiesAPI = {
+  getAll: (params = {}) => fetchAPI(`/properties${buildQuery(params)}`),
+  getById: (id) => fetchAPI(`/properties/${id}`),
+  create: (data) => fetchAPI('/properties', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, data) => fetchAPI(`/properties/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  remove: (id) => fetchAPI(`/properties/${id}`, { method: 'DELETE' }),
+  getTransactions: (id) => fetchAPI(`/properties/${id}/transactions`),
+  getLedger: (id, params = {}) => fetchAPI(`/properties/${id}/ledger${buildQuery(params)}`),
+};
+
+// Assets API
+export const assetsAPI = {
+  getAll: (params = {}) => fetchAPI(`/assets${buildQuery(params)}`),
+  getById: (id) => fetchAPI(`/assets/${id}`),
+  create: (data) => fetchAPI('/assets', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, data) => fetchAPI(`/assets/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  remove: (id) => fetchAPI(`/assets/${id}`, { method: 'DELETE' }),
+  getByPerson: (personId) => fetchAPI(`/people/${personId}/assets`),
+};
+
+// Transactions API
+export const transactionsAPI = {
+  getAll: (params = {}) => fetchAPI(`/transactions${buildQuery(params)}`),
+  getById: (id) => fetchAPI(`/transactions/${id}`),
+  create: (data) => fetchAPI('/transactions', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, data) => fetchAPI(`/transactions/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  remove: (id) => fetchAPI(`/transactions/${id}`, { method: 'DELETE' }),
+  getByPerson: (personId) => fetchAPI(`/people/${personId}/transactions`),
+  getByBusiness: (businessId) => fetchAPI(`/businesses/${businessId}/transactions`),
+  getByProperty: (propertyId) => fetchAPI(`/properties/${propertyId}/transactions`),
+};
+
+// Entity ledger + venue analytics API
+export const ledgerAPI = {
+  get: (entityType, id, params = {}) => fetchAPI(`/${entityType}/${id}/ledger${buildQuery(params)}`),
+  venueStats: (businessId) => fetchAPI(`/businesses/${businessId}/venue-stats`),
+};
+
 export { API_BASE_URL };

--- a/frontend/src/utils/reportGenerators.js
+++ b/frontend/src/utils/reportGenerators.js
@@ -400,3 +400,100 @@ export const downloadWord = async (data, options) => {
   const blob = await Packer.toBlob(doc);
   saveAs(blob, `investigation-report-${Date.now()}.docx`);
 };
+
+// ── Entity Ledger report (issue #43) ────────────────────────────────────────
+
+const money = (v, currency) => {
+  if (v === null || v === undefined) return '—';
+  const n = Number(v);
+  if (isNaN(n)) return '—';
+  const f = n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return currency ? `${f} ${currency}` : f;
+};
+const pretty = (t) => (t || '').replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+export const generateLedgerMarkdown = (ledger) => {
+  const { entity, entries, summary } = ledger;
+  let md = '';
+  md += `# ENTITY LEDGER\n\n`;
+  md += `## ${entity.label || 'Entity'} (${entity.type})\n\n`;
+  md += `**Generated:** ${formatDateTime(new Date())}  \n`;
+  md += `**Classification:** CONFIDENTIAL\n\n---\n\n`;
+
+  md += `## SUMMARY\n\n`;
+  md += `| Metric | Value |\n|--------|-------|\n`;
+  md += `| Value In | ${summary.value_in != null ? money(summary.value_in) : 'mixed currencies'} |\n`;
+  md += `| Value Out | ${summary.value_out != null ? money(summary.value_out) : 'mixed currencies'} |\n`;
+  md += `| Net | ${summary.net != null ? money(summary.net) : 'see per-currency'} |\n`;
+  md += `| Distinct Counterparties | ${summary.distinct_counterparties} |\n\n`;
+
+  if (summary.by_currency && summary.by_currency.length) {
+    md += `### Per Currency\n\n| Currency | In | Out | Net |\n|----------|----|----|-----|\n`;
+    summary.by_currency.forEach(c => {
+      md += `| ${c.currency || 'unspecified'} | ${money(c.value_in)} | ${money(c.value_out)} | ${money(c.net)} |\n`;
+    });
+    md += `\n`;
+  }
+
+  if (summary.count_by_type && Object.keys(summary.count_by_type).length) {
+    md += `### Count by Type\n\n`;
+    Object.entries(summary.count_by_type).forEach(([t, c]) => { md += `- **${pretty(t)}:** ${c}\n`; });
+    md += `\n`;
+  }
+
+  if (summary.assets_currently_held && summary.assets_currently_held.length) {
+    md += `### Currently Held Assets\n\n`;
+    summary.assets_currently_held.forEach(a => { md += `- ${a.name}${a.since ? ` (since ${formatDate(a.since)})` : ''}\n`; });
+    md += `\n`;
+  }
+
+  md += `## LEDGER ENTRIES\n\n`;
+  md += `| Date | Type | Role | Counterparty | Subject | Direction | Value |\n`;
+  md += `|------|------|------|--------------|---------|-----------|-------|\n`;
+  entries.forEach(e => {
+    md += `| ${formatDate(e.occurred_on)} | ${pretty(e.transaction_type)} | ${pretty(e.role)} | ${e.counterparty?.label || '—'} | ${e.subject?.label || '—'} | ${e.value_direction} | ${e.value != null ? money(e.value, e.currency) : '—'} |\n`;
+  });
+  md += `\n---\n*End of Ledger Report*`;
+  return md;
+};
+
+export const downloadLedgerMarkdown = (ledger) => {
+  const md = generateLedgerMarkdown(ledger);
+  const blob = new Blob([md], { type: 'text/markdown' });
+  saveAs(blob, `entity-ledger-${ledger.entity?.type || 'entity'}-${ledger.entity?.id || ''}-${Date.now()}.md`);
+};
+
+export const downloadLedgerWord = async (ledger) => {
+  const { entity, entries, summary } = ledger;
+  const children = [];
+  children.push(p('ENTITY LEDGER', HeadingLevel.TITLE, AlignmentType.CENTER));
+  children.push(p(`${entity.label || 'Entity'} (${entity.type})`, HeadingLevel.HEADING_1, AlignmentType.CENTER));
+  children.push(p(`Generated: ${formatDateTime(new Date())}`, null, AlignmentType.CENTER));
+  children.push(blank());
+
+  children.push(p('Summary', HeadingLevel.HEADING_1));
+  children.push(p(`Value In: ${summary.value_in != null ? money(summary.value_in) : 'mixed currencies'}`));
+  children.push(p(`Value Out: ${summary.value_out != null ? money(summary.value_out) : 'mixed currencies'}`));
+  children.push(p(`Net: ${summary.net != null ? money(summary.net) : 'see per-currency'}`));
+  children.push(p(`Distinct Counterparties: ${summary.distinct_counterparties}`));
+  children.push(blank());
+
+  if (summary.assets_currently_held && summary.assets_currently_held.length) {
+    children.push(p('Currently Held Assets', HeadingLevel.HEADING_2));
+    summary.assets_currently_held.forEach(a => children.push(p(`${a.name}${a.since ? ` (since ${formatDate(a.since)})` : ''}`)));
+    children.push(blank());
+  }
+
+  children.push(p('Ledger Entries', HeadingLevel.HEADING_1));
+  entries.forEach(e => {
+    children.push(p(`${formatDate(e.occurred_on)} — ${pretty(e.transaction_type)} (${pretty(e.role)})`, HeadingLevel.HEADING_2));
+    children.push(p(`Counterparty: ${e.counterparty?.label || '—'} | Subject: ${e.subject?.label || '—'}`));
+    children.push(p(`Direction: ${e.value_direction} | Value: ${e.value != null ? money(e.value, e.currency) : '—'}`));
+    children.push(blank());
+  });
+
+  children.push(p('Classification: CONFIDENTIAL', null, AlignmentType.CENTER));
+  const doc = new Document({ sections: [{ children }] });
+  const blob = await Packer.toBlob(doc);
+  saveAs(blob, `entity-ledger-${entity?.type || 'entity'}-${entity?.id || ''}-${Date.now()}.docx`);
+};

--- a/frontend/src/utils/transactionFormat.js
+++ b/frontend/src/utils/transactionFormat.js
@@ -1,0 +1,47 @@
+// File: frontend/src/utils/transactionFormat.js
+// Shared formatting helpers for the transaction-tracking feature (issue #43).
+
+export const formatMoney = (value, currency) => {
+  if (value === null || value === undefined || value === '') return '—';
+  const num = Number(value);
+  if (isNaN(num)) return '—';
+  const formatted = num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return currency ? `${formatted} ${currency}` : formatted;
+};
+
+export const formatDate = (d) => {
+  if (!d) return '—';
+  try { return new Date(d).toLocaleDateString(); } catch { return String(d); }
+};
+
+export const partyText = (party) => (party && party.label) ? party.label : '—';
+
+export const subjectText = (subject) => {
+  if (!subject) return '—';
+  if (subject.label) return subject.label;
+  return subject.type === 'item' ? '(unspecified item)' : '—';
+};
+
+export const prettyType = (t) => (t || '').replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+// Tailwind classes for a transaction-type badge.
+export const typeBadgeClass = (type) => {
+  const map = {
+    gift: 'bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-300',
+    donation: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+    benefit: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+    sale: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    purchase: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    transfer: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300',
+    assignment: 'bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300',
+    visit: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300',
+  };
+  return map[type] || 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+};
+
+// Colour for a value direction (in / out / neutral).
+export const directionClass = (dir) => {
+  if (dir === 'in') return 'text-green-600 dark:text-green-400';
+  if (dir === 'out') return 'text-red-600 dark:text-red-400';
+  return 'text-gray-500 dark:text-gray-400';
+};


### PR DESCRIPTION
## Summary

Implements the full asset, property and transaction tracking system discussed in #43.

### What's in this PR

- **`transactions` table** — a single event log for gifts, donations, hospitality, sales, purchases, transfers, assignments, loans, and visits. Every change of hands or benefit is one row. The subject of a transaction can be a persistent asset, a business, a property, or a free-text item.
- **`assets` table** — persistent physical goods (watch, laptop, vehicle, tracking device, etc.) with a category, identifier, value, and a **location model**: `with_holder` (auto-follows the current holder's latest known position on the map), `fixed_known` (pinned to one of a person's known locations, with snapshot fallback), `fixed_custom` (its own geocoded address), or `unknown`.
- **`properties` table** — real estate, parcels, and land with coordinates and a derived ownership chain.
- **Chain of custody** for assets, businesses, and properties derived from the transaction log — no denormalised owner column.
- **Per-entity ledger** (`GET /api/:entityType/:id/ledger`) — a unified chronological statement of every transaction an entity appears in (as giver, receiver, subject, or venue), with value-in / value-out / net per currency and current holdings. Surfaced as a "Ledger" tab on Person, Business, and Property detail views, and as an exportable report.
- **Venue analytics** (`GET /api/businesses/:id/venue-stats`) — distinct-visitor count, event count, ranked people list. Answers "which elites are frequenting this restaurant, and who owns it?"
- **Entity-network graph** extended with a toggleable venue/transaction hub layer — businesses and properties appear as nodes, edges weighted by event count, so attention clustering is visible.
- **Global Map** extended with property markers, asset pins, and geocoded-transaction-event markers, each with layer toggles.
- **Three new nav sections**: Transactions, Assets, Properties — each with filterable lists, add/edit forms, and detail modals with chain-of-custody timelines.
- **Settings** — five new model-option taxonomies (`transaction_type`, `transaction_item_category`, `asset_category`, `asset_status`, `property_type`) fully editable in Settings → Data Model.
- **Backend tests** — Jest test suite covering validation rules, custody derivation, ledger role/direction logic, venue-stats aggregation, and geocoding helpers.

### Example use cases covered

| Scenario | How it's recorded |
|---|---|
| Board member receives baseball tickets | `gift` transaction, free-text item |
| Official gets free $100 dinner at Bistro X | `benefit` transaction, `location_business_id` = Bistro X |
| Candidate receives $10k campaign donation | `donation` transaction, value = 10000 |
| Developer sells a parcel | `sale` transaction, `subject_property_id` = parcel |
| Rolex passes from Person A to Person B | `transfer` transaction, `subject_asset_id` = Rolex |
| Tracking device allocated to a subject | `assignment` + `with_holder` location mode |

### Test plan

- [ ] Log in and confirm three new nav sections appear (Transactions, Assets, Properties)
- [ ] Create a Property, confirm geocoding and detail view with ownership timeline
- [ ] Create an Asset with `with_holder` location; assign it to a person via a transaction; confirm it appears at that person's location on the map
- [ ] Record a benefit transaction at a business venue; open that business and confirm the Venue Activity panel shows the visitor
- [ ] Open a Person detail → Ledger tab; confirm the transaction appears with correct in/out direction
- [ ] Open Settings → Data Model; confirm the 5 new option types are editable
- [ ] Toggle the transaction layer in the Relationship Diagram; confirm venue hub nodes appear

---

@zbyte64 — this is the implementation of the spec we discussed in #43. It covers both the use cases you described (gifts, donations, hospitality, venue-to-people analysis) and the persistent-asset custody chain. Would you be willing to take it for a spin and let us know if it matches what you had in mind, or if anything needs adjusting before we merge to `main`? Any feedback welcome — bugs, UX, missing fields, whatever feels off.
