### PR TITLE
Register Russian as a selectable language

### DIFF
--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,9 +1,11 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import en from './locales/en/translation.json';
+import ru from './locales/ru/translation.json';
 
 export const SUPPORTED_LANGUAGES = [
-  { code: 'en', label: 'English' }
+  { code: 'en', label: 'English' },
+  { code: 'ru', label: 'Русский' }
 ];
 
 const STORAGE_KEY = 'ghost_language';
@@ -11,7 +13,8 @@ const storedLanguage = localStorage.getItem(STORAGE_KEY);
 
 i18n.use(initReactI18next).init({
   resources: {
-    en: { translation: en }
+    en: { translation: en },
+    ru: { translation: ru }
   },
   lng: storedLanguage || 'en',
   fallbackLng: 'en',


### PR DESCRIPTION
Wires the Russian translation (merged via Crowdin PR #60) into the app so it can be chosen in **Settings → General**.

## Changes
`frontend/src/i18n.js`:
- Import `ru/translation.json`
- Add `ru: { translation: ru }` to `resources`
- Add `{ code: 'ru', label: 'Русский' }` to `SUPPORTED_LANGUAGES`

## Notes
- Russian catalog is **97.8% translated** (1348/1379 strings, 0 missing keys). The ~31 untranslated strings are product names / non-translatable tokens.
- The other Crowdin locales (de/es/fr/zh) landed in PR #60 as empty placeholders and are intentionally **not** wired up until they're translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015grCWHvgrKr872SETAwrzt